### PR TITLE
Use builtin functions

### DIFF
--- a/bits.h
+++ b/bits.h
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 
+#include "compiler.h"
+
 static const uint64_t BITS_SIZE_MASK[] = {
                  0x0ULL,
 	               0x1ULL,                0x3ULL,                0x7ULL,                0xfULL,
@@ -70,19 +72,30 @@ static const unsigned int BITS_LEN8[] = {
 
 static inline uint16_t bits_swap_u16(uint16_t value)
 {
+#ifdef __HAVE_BUILTIN_BSWAP16__
+  return __builtin_bswap16(value);
+#else
   return (value << 8) | (value >> 8);
+#endif
 }
 
 static inline uint32_t bits_swap_u32(uint32_t value)
 {
+#ifdef __HAVE_BUILTIN_BSWAP32__
+  return __builtin_bswap32(value);
+#else
   return  ((value << 24) & 0xff000000 ) |
           ((value <<  8) & 0x00ff0000 ) |
           ((value >>  8) & 0x0000ff00 ) |
           ((value >> 24) & 0x000000ff );
+#endif
 }
 
 static inline uint64_t bits_swap_u64(uint64_t value)
 {
+#ifdef __HAVE_BUILTIN_BSWAP64__
+  return __builtin_bswap64(value);
+#else
   return  ((value << 56) & 0xff00000000000000ULL) |
           ((value << 40) & 0x00ff000000000000ULL) |
           ((value << 24) & 0x0000ff0000000000ULL) |
@@ -91,6 +104,7 @@ static inline uint64_t bits_swap_u64(uint64_t value)
           ((value >> 24) & 0x0000000000ff0000ULL) |
           ((value >> 40) & 0x000000000000ff00ULL) |
           ((value >> 56) & 0x00000000000000ffULL);
+#endif
 }
 
 static inline unsigned int bits_len_u8(uint8_t value)

--- a/bits.h
+++ b/bits.h
@@ -126,6 +126,9 @@ static inline unsigned int bits_len_u16(uint16_t value)
 
 static inline unsigned int bits_len_u32(uint32_t value)
 {
+#ifdef __HAVE_BUILTIN_CLZ__
+  return 32 - __builtin_clz(value | 1);
+#else
   unsigned int n = 0;
 
   if (value > 0x0000ffff) {
@@ -138,10 +141,14 @@ static inline unsigned int bits_len_u32(uint32_t value)
   }
 
   return n + BITS_LEN8[value];
+#endif
 }
 
 static inline unsigned int bits_len_u64(uint64_t value)
 {
+#ifdef __HAVE_BUILTIN_CLZLL__
+  return 64 - __builtin_clzll(value | 1ULL);
+#else
   unsigned int n = 0;
 
   if (value > 0x00000000ffffffffULL) {
@@ -158,6 +165,7 @@ static inline unsigned int bits_len_u64(uint64_t value)
   }
 
   return n + BITS_LEN8[value];
+#endif
 }
 
 #endif /* VTENC_BITS_H_ */

--- a/compiler.h
+++ b/compiler.h
@@ -19,4 +19,9 @@
 #define __HAVE_BUILTIN_BSWAP16__
 #endif
 
+#if GCC_VERSION >= 40000
+#define __HAVE_BUILTIN_CLZ__
+#define __HAVE_BUILTIN_CLZLL__
+#endif
+
 #endif /* VTENC_COMPILER_H_ */

--- a/compiler.h
+++ b/compiler.h
@@ -1,0 +1,22 @@
+/**
+  Copyright (c) 2019 Vicente Romero Calero. All rights reserved.
+  Licensed under the MIT License.
+  See LICENSE file in the project root for full license information.
+ */
+#ifndef VTENC_COMPILER_H_
+#define VTENC_COMPILER_H_
+
+#define GCC_VERSION (__GNUC__ * 10000		\
+		     + __GNUC_MINOR__ * 100	\
+		     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 40300
+#define __HAVE_BUILTIN_BSWAP32__
+#define __HAVE_BUILTIN_BSWAP64__
+#endif
+
+#if GCC_VERSION >= 40800
+#define __HAVE_BUILTIN_BSWAP16__
+#endif
+
+#endif /* VTENC_COMPILER_H_ */


### PR DESCRIPTION
* Use `__builtin_bswap*` (if available) in `bits_swap*` functions.
* Use `__builtin_clz` and `__builtin_clzll` (if available) in `bits_len_u32` and `bits_len_u64` functions respectively.