### PR TITLE
Minimum cluster length to be serialised

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -11,6 +11,7 @@ void vtenc_decoder_init(VtencDecoder *dec)
 {
   dec->allow_repeated_values  = 1;
   dec->skip_full_subtrees     = 1;
+  dec->min_cluster_length     = 1;
   dec->last_error_code        = VtencErrorNoError;
 }
 

--- a/decode_generic.h
+++ b/decode_generic.h
@@ -213,15 +213,16 @@ void vtenc_decode(WIDTH)(VtencDecoder *dec, const uint8_t *in, size_t in_len,
 
   dec->last_error_code = VtencErrorNoError;
 
+  DEC_RETURN_ON_ERROR(&ctx, dec,
+    decctx_init(WIDTH)(&ctx, dec, in, in_len, out, out_len)
+  );
+
   if ((uint64_t)out_len > max_values) {
     DEC_RETURN_WITH_CODE(&ctx, dec, VtencErrorOutputTooBig);
   }
 
   memset(out, 0, out_len * sizeof(*out));
 
-  DEC_RETURN_ON_ERROR(&ctx, dec,
-    decctx_init(WIDTH)(&ctx, dec, in, in_len, out, out_len)
-  );
 
   DEC_RETURN_ON_ERROR(&ctx, dec, decode_bits_tree(WIDTH)(&ctx));
 

--- a/decode_generic.h
+++ b/decode_generic.h
@@ -17,6 +17,7 @@
 #define decctx_init(_width_) WIDTH_SUFFIX(decctx_init, _width_)
 #define decctx_add_cluster(_width_) WIDTH_SUFFIX(decctx_add_cluster, _width_)
 #define decctx_close(_width_) WIDTH_SUFFIX(decctx_close, _width_)
+#define decode_lower_bits_single(_width_) WIDTH_SUFFIX(decode_lower_bits_single, _width_)
 #define decode_lower_bits(_width_) WIDTH_SUFFIX(decode_lower_bits, _width_)
 #define decode_full_subtree(_width_) WIDTH_SUFFIX(decode_full_subtree, _width_)
 #define set_ones_at_bit_pos(_width_) WIDTH_SUFFIX(set_ones_at_bit_pos, _width_)
@@ -42,6 +43,7 @@ struct DecodeCtx(WIDTH) {
   TYPE *values;
   size_t values_len;
   int reconstruct_full_subtrees;
+  size_t min_cluster_length;
   struct BitClusterStack *cl_stack;
   BSReader bits_reader;
 };
@@ -58,6 +60,8 @@ static VtencErrorCode decctx_init(WIDTH)(struct DecodeCtx(WIDTH) *ctx,
    * with no repeated values.
    */
   ctx->reconstruct_full_subtrees = !dec->allow_repeated_values && dec->skip_full_subtrees;
+
+  ctx->min_cluster_length = dec->min_cluster_length;
 
   ctx->cl_stack = bclstack_new(WIDTH);
   if (ctx->cl_stack == NULL) return VtencErrorMemoryAlloc;
@@ -81,10 +85,10 @@ static inline void decctx_close(WIDTH)(struct DecodeCtx(WIDTH) *ctx)
   if (ctx->cl_stack != NULL) bclstack_free(&(ctx->cl_stack));
 }
 
-static inline VtencErrorCode decode_lower_bits(WIDTH)(struct DecodeCtx(WIDTH) *ctx,
+static inline VtencErrorCode decode_lower_bits_single(WIDTH)(struct DecodeCtx(WIDTH) *ctx,
   TYPE *value, unsigned int n_bits)
 {
-#if WIDTH == 64
+#if WIDTH > BIT_STREAM_MAX_READ
   uint64_t lower;
   unsigned int shift = 0;
 
@@ -107,6 +111,18 @@ static inline VtencErrorCode decode_lower_bits(WIDTH)(struct DecodeCtx(WIDTH) *c
 
   return VtencErrorNoError;
 #endif
+}
+
+static inline VtencErrorCode decode_lower_bits(WIDTH)(struct DecodeCtx(WIDTH) *ctx,
+  TYPE *values, size_t values_len, unsigned int n_bits)
+{
+  size_t i;
+
+  for (i = 0; i < values_len; ++i) {
+    RETURN_IF_ERROR(decode_lower_bits_single(WIDTH)(ctx, &values[i], n_bits));
+  }
+
+  return VtencErrorNoError;
 }
 
 static inline void decode_full_subtree(WIDTH)(TYPE *values, size_t values_len)
@@ -145,8 +161,13 @@ static VtencErrorCode decode_bits_tree(WIDTH)(struct DecodeCtx(WIDTH) *ctx)
     cl_bit_pos = cluster->bit_pos;
     cur_bit_pos = cl_bit_pos - 1;
 
-    if (cl_len == 1) {
-      RETURN_IF_ERROR(decode_lower_bits(WIDTH)(ctx, ctx->values + cl_from, cl_bit_pos));
+    if (cl_len <= ctx->min_cluster_length) {
+      RETURN_IF_ERROR(decode_lower_bits(WIDTH)(
+        ctx,
+        ctx->values + cl_from,
+        cl_len,
+        cl_bit_pos
+      ));
       continue;
     }
 

--- a/encode.c
+++ b/encode.c
@@ -11,6 +11,7 @@ void vtenc_encoder_init(VtencEncoder *enc)
 {
   enc->allow_repeated_values  = 1;
   enc->skip_full_subtrees     = 1;
+  enc->min_cluster_length     = 1;
   enc->last_error_code        = VtencErrorNoError;
 }
 

--- a/encode_generic.h
+++ b/encode_generic.h
@@ -179,13 +179,13 @@ size_t vtenc_encode(WIDTH)(VtencEncoder *enc, const TYPE *in, size_t in_len,
 
   enc->last_error_code = VtencErrorNoError;
 
-  if ((uint64_t)in_len > max_values) {
-    ENC_RETURN_WITH_CODE(&ctx, enc, VtencErrorInputTooBig);
-  }
-
   ENC_RETURN_ON_ERROR(&ctx, enc,
     encctx_init(WIDTH)(&ctx, enc, in, in_len, out, out_cap)
   );
+
+  if ((uint64_t)in_len > max_values) {
+    ENC_RETURN_WITH_CODE(&ctx, enc, VtencErrorInputTooBig);
+  }
 
   ENC_RETURN_ON_ERROR(&ctx, enc, encode_bits_tree(WIDTH)(&ctx));
 

--- a/encode_generic.h
+++ b/encode_generic.h
@@ -92,7 +92,7 @@ static inline size_t encctx_close(WIDTH)(struct EncodeCtx(WIDTH) *ctx)
 static inline VtencErrorCode encode_lower_bits_single(WIDTH)(struct EncodeCtx(WIDTH) *ctx,
   uint64_t value, unsigned int n_bits)
 {
-#if WIDTH == 64
+#if WIDTH > BIT_STREAM_MAX_WRITE
   if (n_bits > BIT_STREAM_MAX_WRITE) {
     RETURN_IF_ERROR(bswriter_write(
       &(ctx->bits_writer),

--- a/tests/encdec.c
+++ b/tests/encdec.c
@@ -125,7 +125,8 @@ int encdec_decode(struct EncDec *encdec)
 {
   VtencDecoder decoder = {
     .allow_repeated_values = encdec->allow_repeated_values,
-    .skip_full_subtrees = encdec->skip_full_subtrees
+    .skip_full_subtrees = encdec->skip_full_subtrees,
+    .min_cluster_length = encdec->min_cluster_length
   };
 
   encdec->ctx.dec_out_len = encdec->ctx.in_len;

--- a/tests/encdec.c
+++ b/tests/encdec.c
@@ -47,20 +47,21 @@ static const struct EncDecFuncs enc_dec_64_funcs = {
 
 static void encdecctx_init(struct EncDecCtx *ctx)
 {
-  ctx->in = NULL;
-  ctx->in_len = 0;
-  ctx->enc_out = NULL;
-  ctx->enc_out_len = 0;
-  ctx->dec_out = NULL;
-  ctx->dec_out_len = 0;
+  ctx->in           = NULL;
+  ctx->in_len       = 0;
+  ctx->enc_out      = NULL;
+  ctx->enc_out_len  = 0;
+  ctx->dec_out      = NULL;
+  ctx->dec_out_len  = 0;
 }
 
 void encdec_init(struct EncDec *encdec, const struct EncDecFuncs *funcs)
 {
   encdec->allow_repeated_values = 1;
-  encdec->skip_full_subtrees = 1;
+  encdec->skip_full_subtrees    = 1;
+  encdec->min_cluster_length    = 1;
+  encdec->funcs                 = funcs;
   encdecctx_init(&(encdec->ctx));
-  encdec->funcs = funcs;
 }
 
 void encdec_init8(struct EncDec *encdec)
@@ -88,7 +89,8 @@ int encdec_encode(struct EncDec *encdec, const void *in, size_t in_len)
   size_t enc_out_cap;
   VtencEncoder encoder = {
     .allow_repeated_values = encdec->allow_repeated_values,
-    .skip_full_subtrees = encdec->skip_full_subtrees
+    .skip_full_subtrees = encdec->skip_full_subtrees,
+    .min_cluster_length = encdec->min_cluster_length
   };
 
   encdec->ctx.in = in;

--- a/tests/encdec.h
+++ b/tests/encdec.h
@@ -35,6 +35,7 @@ struct EncDecCtx {
 struct EncDec {
   int allow_repeated_values;
   int skip_full_subtrees;
+  size_t min_cluster_length;
   struct EncDecCtx ctx;
   const struct EncDecFuncs *funcs;
 };

--- a/tests/unit/decode_test.c
+++ b/tests/unit/decode_test.c
@@ -18,6 +18,7 @@ int test_vtenc_decoder_init(void)
 
   EXPECT_TRUE(dec.allow_repeated_values == 1);
   EXPECT_TRUE(dec.skip_full_subtrees == 1);
+  EXPECT_TRUE(dec.min_cluster_length == 1);
   EXPECT_TRUE(dec.last_error_code == VtencErrorNoError);
 
   return 1;
@@ -45,7 +46,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x0e},
       .bytes_len = 1,
@@ -60,7 +62,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -75,7 +78,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -90,7 +94,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x26},
       .bytes_len = 1,
@@ -105,7 +110,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x98, 0x66, 0xc9, 0x55, 0xd1, 0x65, 0x39, 0x27, 0x54
@@ -122,7 +128,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x87, 0xa8, 0x0e, 0x04, 0x00, 0xe0, 0x01},
       .bytes_len = 7,
@@ -137,7 +144,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0xff},
       .bytes_len = 1,
@@ -152,7 +160,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -167,7 +176,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -182,7 +192,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -215,7 +226,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x21},
       .bytes_len = 1,
@@ -230,7 +242,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x48, 0x90, 0x44, 0x44, 0x04},
       .bytes_len = 5,
@@ -245,7 +258,8 @@ static struct DecodeTestCase test_cases8[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x8c, 0xaa, 0x72, 0x14, 0xdd, 0x00},
       .bytes_len = 6,
@@ -263,7 +277,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x0e},
       .bytes_len = 1,
@@ -278,7 +293,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -293,7 +309,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -308,7 +325,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x26, 0x36},
       .bytes_len = 2,
@@ -323,7 +341,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x6d, 0x74, 0xb8, 0x55, 0x46, 0x49, 0x61, 0xc0, 0x6b, 0xfa, 0xcd, 0x62,
@@ -341,7 +360,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x88, 0xd3, 0x16, 0x45, 0x81, 0xb6, 0xf8, 0x99, 0x79, 0x06
@@ -358,7 +378,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0xff},
       .bytes_len = 1,
@@ -373,7 +394,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -388,7 +410,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -403,7 +426,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x33, 0x5a},
       .bytes_len = 2,
@@ -418,7 +442,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x96, 0xae, 0x18, 0x0e, 0x10, 0x42, 0xbe, 0x53, 0x26, 0x24, 0x7c, 0x80,
@@ -436,7 +461,8 @@ static struct DecodeTestCase test_cases16[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x8c, 0x24, 0x00, 0x92, 0x20, 0x09, 0x80, 0x00, 0x08, 0x08, 0x80
@@ -459,7 +485,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x0e},
       .bytes_len = 1,
@@ -474,7 +501,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -489,7 +517,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -504,7 +533,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x59, 0x48, 0x4e, 0x2b},
       .bytes_len = 4,
@@ -519,7 +549,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0xa5, 0xa0, 0x7c, 0xa2, 0xc5, 0x35, 0x04, 0x9d, 0xc0, 0x62, 0x48, 0x07,
@@ -539,7 +570,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0xb6, 0xa9, 0x08, 0x2a, 0xa8, 0x88, 0xaa, 0x20, 0x48, 0x90, 0x20, 0x48,
@@ -559,7 +591,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0xff},
       .bytes_len = 1,
@@ -574,7 +607,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -589,7 +623,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -604,7 +639,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x42, 0xba, 0xe3, 0x77},
       .bytes_len = 4,
@@ -619,7 +655,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0xdc, 0x4d, 0x30, 0x20, 0xed, 0x71, 0x95, 0xf9, 0x16, 0xde, 0xd9, 0xf1,
@@ -639,7 +676,8 @@ static struct DecodeTestCase test_cases32[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0xee, 0xee, 0xee, 0xee, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -665,7 +703,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0x0e},
       .bytes_len = 1,
@@ -680,7 +719,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -695,7 +735,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -710,7 +751,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x61, 0x22, 0xc4, 0xfe, 0x90, 0x81, 0x77, 0xab
@@ -727,7 +769,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x24, 0x49, 0x92, 0x24, 0x49, 0x92, 0xe4, 0x54, 0x35, 0xc7, 0x1d, 0x4b,
@@ -748,7 +791,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x6d, 0xdb, 0xb6, 0x6d, 0xdb, 0xb6, 0x6d, 0xa7, 0xa2, 0xa2, 0xa2, 0xa2,
@@ -770,7 +814,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){0xfe},
       .bytes_len = 1,
@@ -785,7 +830,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -800,7 +846,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){},
       .bytes_len = 0,
@@ -815,7 +862,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
@@ -832,7 +880,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcd, 0xfd, 0xdf, 0xfd, 0xdf, 0xfd,
@@ -855,7 +904,8 @@ static struct DecodeTestCase test_cases64[] = {
     .input = {
       .decoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .bytes = (uint8_t []){
         0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88,

--- a/tests/unit/decode_test.c
+++ b/tests/unit/decode_test.c
@@ -269,6 +269,70 @@ static struct DecodeTestCase test_cases8[] = {
       .values = (uint8_t []){13, 77, 88, 93, 149, 212},
       .last_error_code = VtencErrorNoError
     }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 0,
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 2
+      },
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x30, 0x0d},
+      .bytes_len = 5,
+      .values_len = 6,
+    },
+    .expected_output = {
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 0,
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 3
+      },
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x30, 0x0d},
+      .bytes_len = 5,
+      .values_len = 6,
+    },
+    .expected_output = {
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 0,
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 4
+      },
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x0c, 0x2e},
+      .bytes_len = 5,
+      .values_len = 6,
+    },
+    .expected_output = {
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 0,
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 8
+      },
+      .bytes = (uint8_t []){0x02, 0x03, 0x08, 0x0b, 0x10, 0x7a},
+      .bytes_len = 6,
+      .values_len = 6,
+    },
+    .expected_output = {
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .last_error_code = VtencErrorNoError
+    }
   }
 };
 
@@ -475,6 +539,60 @@ static struct DecodeTestCase test_cases16[] = {
         14000, 14001, 14002, 14003, 14004, 14005, 14006, 14007,
         20000, 20001, 20002, 20003
       },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .bytes = (uint8_t []){
+        0x84, 0x05, 0x50, 0xe5, 0x05, 0xd4, 0x7c, 0x08, 0x2c, 0x01
+      },
+      .bytes_len = 10,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .bytes = (uint8_t []){
+        0x84, 0x05, 0x7c, 0x08, 0xb0, 0x04, 0xe5, 0x25, 0x50, 0x13
+      },
+      .bytes_len = 10,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .bytes = (uint8_t []){
+        0x1f, 0x02, 0x58, 0x02, 0xe5, 0x25, 0xa0, 0x26, 0xb0, 0x80
+      },
+      .bytes_len = 10,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
       .last_error_code = VtencErrorNoError
     }
   }
@@ -692,6 +810,69 @@ static struct DecodeTestCase test_cases32[] = {
         0xa500, 0xa501, 0xa502, 0xa503,
         0x4bbb00, 0x4bbb01,
         0xffff00, 0xffff01, 0xffff02, 0xffff03, 0xffff04, 0xffff05, 0xffff06, 0xffff07
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .bytes = (uint8_t []){
+        0xa0, 0xff, 0x5b, 0x04, 0x42, 0x82, 0x14, 0xf4, 0xce, 0xd8, 0xf7, 0xce,
+        0x58, 0xc1, 0x6a, 0x7c, 0xc2, 0x6a, 0x3c
+      },
+      .bytes_len = 19,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .bytes = (uint8_t []){
+        0xa0, 0xff, 0x5b, 0x04, 0x52, 0xb0, 0x1a, 0x8f, 0x24, 0xac, 0xc6, 0x23,
+        0xd0, 0x3b, 0x63, 0xc9, 0xf7, 0xce, 0x58, 0x02
+      },
+      .bytes_len = 20,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .bytes = (uint8_t []){
+        0x05, 0xab, 0xf1, 0x88, 0x09, 0xab, 0xf1, 0x88, 0xd0, 0x3b, 0x63, 0x89,
+        0xdf, 0x3b, 0x63, 0x89, 0xfe, 0x6f, 0x11, 0xc8
+      },
+      .bytes_len = 20,
+      .values_len = 5
+    },
+    .expected_output = {
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
       },
       .last_error_code = VtencErrorNoError
     }
@@ -921,6 +1102,81 @@ static struct DecodeTestCase test_cases64[] = {
         0x20000000ULL, 0x20000001ULL, 0x20000002ULL, 0x20000003ULL,
         0x80000000ULL, 0x80000001ULL,
         0x2000000000ULL, 0x2000000001ULL
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .bytes = (uint8_t []){
+        0xb6, 0x6d, 0xdb, 0xb6, 0x6d, 0xdb, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x24, 0x49, 0x92, 0x24, 0x49,
+        0x92, 0x24, 0x49, 0x92, 0x24, 0x15, 0x00, 0xf0, 0x00, 0x10, 0x00, 0xf0,
+        0x00, 0x00
+      },
+      .bytes_len = 38,
+      .values_len = 6
+    },
+    .expected_output = {
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .bytes = (uint8_t []){
+        0xb6, 0x6d, 0xdb, 0xb6, 0x6d, 0xdb, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0xc0,
+        0x0f, 0x00, 0x00, 0x00, 0x00, 0x70, 0x00, 0x40, 0x00, 0x00, 0x00, 0xfc,
+        0x00, 0x10, 0x00, 0x00, 0x00, 0x03
+      },
+      .bytes_len = 42,
+      .values_len = 6
+    },
+    .expected_output = {
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
+      },
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .decoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .bytes = (uint8_t []){
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00,
+        0x00, 0x30, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x30, 0x00, 0x00,
+        0x0f, 0x00, 0x01, 0x00, 0x00, 0x30, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x60, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x60, 0x00, 0x00
+      },
+      .bytes_len = 48,
+      .values_len = 6
+    },
+    .expected_output = {
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
       },
       .last_error_code = VtencErrorNoError
     }

--- a/tests/unit/encode_test.c
+++ b/tests/unit/encode_test.c
@@ -236,6 +236,70 @@ static struct EncodeTestCase test_cases8[] = {
       .bytes_len = 6,
       .last_error_code = VtencErrorNoError
     }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x30, 0x0d},
+      .bytes_len = 5,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 3
+      },
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x30, 0x0d},
+      .bytes_len = 5,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){0xae, 0x5e, 0x82, 0x0c, 0x2e},
+      .bytes_len = 5,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .values = (uint8_t []){2, 3, 8, 11, 16, 122},
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){0x02, 0x03, 0x08, 0x0b, 0x10, 0x7a},
+      .bytes_len = 6,
+      .last_error_code = VtencErrorNoError
+    }
   }
 };
 
@@ -410,6 +474,60 @@ static struct EncodeTestCase test_cases16[] = {
         0x8c, 0x24, 0x00, 0x92, 0x20, 0x09, 0x80, 0x00, 0x08, 0x08, 0x80
       },
       .bytes_len = 11,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0x84, 0x05, 0x50, 0xe5, 0x05, 0xd4, 0x7c, 0x08, 0x2c, 0x01
+      },
+      .bytes_len = 10,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0x84, 0x05, 0x7c, 0x08, 0xb0, 0x04, 0xe5, 0x25, 0x50, 0x13
+      },
+      .bytes_len = 10,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .values = (uint16_t []){543, 600, 9701, 9888, 32944},
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0x1f, 0x02, 0x58, 0x02, 0xe5, 0x25, 0xa0, 0x26, 0xb0, 0x80
+      },
+      .bytes_len = 10,
       .last_error_code = VtencErrorNoError
     }
   }
@@ -598,6 +716,69 @@ static struct EncodeTestCase test_cases32[] = {
       .bytes_len = 28,
       .last_error_code = VtencErrorNoError
     }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
+      },
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0xa0, 0xff, 0x5b, 0x04, 0x42, 0x82, 0x14, 0xf4, 0xce, 0xd8, 0xf7, 0xce,
+        0x58, 0xc1, 0x6a, 0x7c, 0xc2, 0x6a, 0x3c
+      },
+      .bytes_len = 19,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
+      },
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0xa0, 0xff, 0x5b, 0x04, 0x52, 0xb0, 0x1a, 0x8f, 0x24, 0xac, 0xc6, 0x23,
+        0xd0, 0x3b, 0x63, 0xc9, 0xf7, 0xce, 0x58, 0x02
+      },
+      .bytes_len = 20,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .values = (uint32_t []){
+        0x88f1ab05, 0x88f1ab09, 0x89633bd0, 0x89633bdf, 0xc8116ffe
+      },
+      .values_len = 5
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0x05, 0xab, 0xf1, 0x88, 0x09, 0xab, 0xf1, 0x88, 0xd0, 0x3b, 0x63, 0x89,
+        0xdf, 0x3b, 0x63, 0x89, 0xfe, 0x6f, 0x11, 0xc8
+      },
+      .bytes_len = 20,
+      .last_error_code = VtencErrorNoError
+    }
   }
 };
 
@@ -777,6 +958,81 @@ static struct EncodeTestCase test_cases64[] = {
         0x24, 0x49, 0x92, 0x24, 0x49, 0x92, 0x24, 0x01
       },
       .bytes_len = 44,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 2
+      },
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
+      },
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0xb6, 0x6d, 0xdb, 0xb6, 0x6d, 0xdb, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x24, 0x49, 0x92, 0x24, 0x49,
+        0x92, 0x24, 0x49, 0x92, 0x24, 0x15, 0x00, 0xf0, 0x00, 0x10, 0x00, 0xf0,
+        0x00, 0x00
+      },
+      .bytes_len = 38,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 4
+      },
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
+      },
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0xb6, 0x6d, 0xdb, 0xb6, 0x6d, 0xdb, 0x66, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0xc0,
+        0x0f, 0x00, 0x00, 0x00, 0x00, 0x70, 0x00, 0x40, 0x00, 0x00, 0x00, 0xfc,
+        0x00, 0x10, 0x00, 0x00, 0x00, 0x03
+      },
+      .bytes_len = 42,
+      .last_error_code = VtencErrorNoError
+    }
+  },
+  {
+    .input = {
+      .encoder = {
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 8
+      },
+      .values = (uint64_t []){
+        0x300000000001ULL, 0x30000000000fULL,
+        0x300000010001ULL, 0x30000001000fULL,
+        0x600000000001ULL, 0x60000000000fULL
+      },
+      .values_len = 6
+    },
+    .expected_output = {
+      .bytes = (uint8_t []){
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00,
+        0x00, 0x30, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x30, 0x00, 0x00,
+        0x0f, 0x00, 0x01, 0x00, 0x00, 0x30, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x60, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x60, 0x00, 0x00
+      },
+      .bytes_len = 48,
       .last_error_code = VtencErrorNoError
     }
   }

--- a/tests/unit/encode_test.c
+++ b/tests/unit/encode_test.c
@@ -43,8 +43,9 @@ static struct EncodeTestCase test_cases8[] = {
   {
     .input = {
       .encoder = {
-        .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){},
       .values_len = 0xffffffffffffffffULL
@@ -59,7 +60,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){},
       .values_len = 0
@@ -74,7 +76,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){38},
       .values_len = 1
@@ -89,7 +92,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){5, 22, 23, 44, 62, 69, 109, 113, 178, 194, 206},
       .values_len = 11
@@ -106,7 +110,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){57, 57, 57, 111, 111, 111, 111, 208, 208},
       .values_len = 9
@@ -121,7 +126,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){},
       .values_len = 257
@@ -136,7 +142,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){},
       .values_len = 0
@@ -151,7 +158,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -184,7 +192,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){33},
       .values_len = 1
@@ -199,7 +208,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){0, 1, 2, 3, 4, 5, 6, 7, 160, 161, 162, 163},
       .values_len = 12
@@ -214,7 +224,8 @@ static struct EncodeTestCase test_cases8[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint8_t []){13, 77, 88, 93, 149, 212},
       .values_len = 6
@@ -231,8 +242,9 @@ static struct EncodeTestCase test_cases16[] = {
   {
     .input = {
       .encoder = {
-        .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){},
       .values_len = 0xffffffffffffffffULL
@@ -247,7 +259,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){},
       .values_len = 0
@@ -262,7 +275,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){13862},
       .values_len = 1
@@ -277,7 +291,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){1099, 2227, 8102, 27654, 29001, 35511, 50083},
       .values_len = 7
@@ -295,7 +310,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){677, 677, 677, 8881, 8881, 8881, 8881, 8881},
       .values_len = 8
@@ -312,7 +328,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){},
       .values_len = 65537
@@ -327,7 +344,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){},
       .values_len = 0
@@ -342,7 +360,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){23091},
       .values_len = 1
@@ -357,7 +376,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){1655, 3391, 4111, 8770, 29006, 32712, 32993, 58042},
       .values_len = 8
@@ -375,7 +395,8 @@ static struct EncodeTestCase test_cases16[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint16_t []){
         14000, 14001, 14002, 14003, 14004, 14005, 14006, 14007,
@@ -397,8 +418,9 @@ static struct EncodeTestCase test_cases32[] = {
   {
     .input = {
       .encoder = {
-        .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){},
       .values_len = 0xffffffffffffffffULL
@@ -413,7 +435,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){},
       .values_len = 0
@@ -428,7 +451,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){726550617},
       .values_len = 1
@@ -445,7 +469,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){5348, 13089333, 88199704, 271008013, 1451881090},
       .values_len = 5
@@ -463,7 +488,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){
         77865901, 77865901, 77865901, 77865901, 314976310, 314976310
@@ -483,7 +509,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){},
       .values_len = 0x200000000
@@ -498,7 +525,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){},
       .values_len = 0
@@ -513,7 +541,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){0x77e3ba42},
       .values_len = 1
@@ -528,7 +557,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){
         0x98b204, 0x122fabb4, 0x378ecef0, 0x77ccab8f, 0xa40609bb
@@ -548,7 +578,8 @@ static struct EncodeTestCase test_cases32[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint32_t []){
         0xa500, 0xa501, 0xa502, 0xa503,
@@ -573,8 +604,9 @@ static struct EncodeTestCase test_cases64[] = {
   {
     .input = {
       .encoder = {
-        .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .allow_repeated_values = 1,
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){},
       .values_len = 0xffffffffffffffffULL
@@ -589,7 +621,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){},
       .values_len = 0
@@ -604,7 +637,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){0xab778190fec42261ULL},
       .values_len = 1
@@ -621,7 +655,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){
         0x12a6ULL, 0x8addf0ULL, 0xffa1b4bbULL, 0x21258ee39aaaULL
@@ -642,7 +677,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 1,
-        .skip_full_subtrees = 0
+        .skip_full_subtrees = 0,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){
         0x55555555ULL, 0x55555555ULL, 0x55555555ULL,
@@ -664,7 +700,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){},
       .values_len = 0
@@ -679,7 +716,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){0x1122334455667788ULL},
       .values_len = 1
@@ -696,7 +734,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){
         0x11223344ULL, 0xaabbccddULL, 0x1010101010ULL, 0x5555555555ULL, 0xf0f0f0f0f0ULL,
@@ -719,7 +758,8 @@ static struct EncodeTestCase test_cases64[] = {
     .input = {
       .encoder = {
         .allow_repeated_values = 0,
-        .skip_full_subtrees = 1
+        .skip_full_subtrees = 1,
+        .min_cluster_length = 1
       },
       .values = (uint64_t []){
         0x20000000ULL, 0x20000001ULL, 0x20000002ULL, 0x20000003ULL,

--- a/tests/unit/encode_test.c
+++ b/tests/unit/encode_test.c
@@ -17,6 +17,7 @@ int test_vtenc_encoder_init(void)
 
   EXPECT_TRUE(enc.allow_repeated_values == 1);
   EXPECT_TRUE(enc.skip_full_subtrees == 1);
+  EXPECT_TRUE(enc.min_cluster_length == 1);
   EXPECT_TRUE(enc.last_error_code == VtencErrorNoError);
 
   return 1;

--- a/vtenc.h
+++ b/vtenc.h
@@ -126,6 +126,11 @@ typedef struct {
   int skip_full_subtrees;
 
   /**
+   * Minimum cluster length to serialise.
+   */
+  size_t min_cluster_length;
+
+  /**
    * 'Returning state' after calling a decode function. It'll hold the error
    * code value if the decode function fails, or a 'VtencErrorNoError' value if
    * the function runs successfully.

--- a/vtenc.h
+++ b/vtenc.h
@@ -50,6 +50,11 @@ typedef struct {
   int skip_full_subtrees;
 
   /**
+   * Minimum cluster length to serialise.
+   */
+  size_t min_cluster_length;
+
+  /**
    * 'Returning state' after calling a encode function. It'll hold the error
    * code value if the encode function fails, or a 'VtencErrorNoError' value if
    * the function runs successfully.


### PR DESCRIPTION
This PR adds a new encoding parameter to `VtencEncoder` and `VtencDecoder` structures: `min_cluster_length`. This value sets the minimum cluster length to be (de)serialised on the Bit Cluster Tree DFS (de)serialisation.

When a cluster length less than or equal to `min_cluster_length` is found, its value is serialised and encoded as usual, but its subtree is not processed in the same way. Instead, lower bits of the values in that subtree are encoded.

This parameter adds the ability of fine-tune the tradeoff between compression ratio and speed.