### PR TITLE
Re-implement BitClusterStack to use a fixed-size array instead of allocating memory

### DIFF
--- a/encode_generic.h
+++ b/encode_generic.h
@@ -48,7 +48,7 @@ struct EncodeCtx(WIDTH) {
   size_t                  values_len;
   int                     skip_full_subtrees;
   size_t                  min_cluster_length;
-  struct BitClusterStack  *cl_stack;
+  struct BitClusterStack  cl_stack;
   BSWriter                bits_writer;
 };
 
@@ -67,16 +67,13 @@ static VtencErrorCode encctx_init(WIDTH)(struct EncodeCtx(WIDTH) *ctx,
 
   ctx->min_cluster_length = enc->min_cluster_length;
 
-  ctx->cl_stack = bclstack_new(WIDTH);
-  if (ctx->cl_stack == NULL) return VtencErrorMemoryAlloc;
+  bclstack_init(&ctx->cl_stack);
 
   return bswriter_init(&(ctx->bits_writer), out, out_cap);
 }
 
 static inline size_t encctx_close(WIDTH)(struct EncodeCtx(WIDTH) *ctx)
 {
-  if (ctx->cl_stack != NULL) bclstack_free(&(ctx->cl_stack));
-
   return bswriter_close(&(ctx->bits_writer));
 }
 
@@ -120,17 +117,17 @@ static inline void bcltree_add(WIDTH)(struct EncodeCtx(WIDTH) *ctx,
   if (cl_len == 0)
     return;
 
-  bclstack_put(ctx->cl_stack, cl_from, cl_len, cl_bit_pos);
+  bclstack_put(&ctx->cl_stack, cl_from, cl_len, cl_bit_pos);
 }
 
 static inline int bcltree_has_more(WIDTH)(struct EncodeCtx(WIDTH) *ctx)
 {
-  return !bclstack_empty(ctx->cl_stack);
+  return !bclstack_empty(&ctx->cl_stack);
 }
 
 static inline struct BitCluster *bcltree_next(WIDTH)(struct EncodeCtx(WIDTH) *ctx)
 {
-  return bclstack_get(ctx->cl_stack);
+  return bclstack_get(&ctx->cl_stack);
 }
 
 static VtencErrorCode encode_bit_cluster_tree(WIDTH)(struct EncodeCtx(WIDTH) *ctx)

--- a/tests/unit/bitcluster_test.c
+++ b/tests/unit/bitcluster_test.c
@@ -6,49 +6,49 @@
 #include "unit_tests.h"
 #include "../../bitcluster.h"
 
-int test_bclstack_new(void)
+int test_bclstack_init(void)
 {
-  struct BitClusterStack *s = bclstack_new(10);
+  struct BitClusterStack s;
 
-  EXPECT_TRUE(bclstack_empty(s));
+  bclstack_init(&s);
 
-  bclstack_free(&s);
+  EXPECT_TRUE(bclstack_empty(&s));
 
   return 1;
 }
 
 int test_bclstack_put_and_get(void)
 {
-  struct BitClusterStack *s = bclstack_new(3);
+  struct BitClusterStack s;
   struct BitCluster *cl;
 
-  EXPECT_TRUE(bclstack_get(s) == NULL);
+  bclstack_init(&s);
 
-  bclstack_put(s, 0, 5, 0);
-  bclstack_put(s, 5, 2, 0);
-  bclstack_put(s, 7, 3, 1);
+  EXPECT_TRUE(bclstack_get(&s) == NULL);
 
-  EXPECT_TRUE(bclstack_length(s) == 3);
+  bclstack_put(&s, 0, 5, 0);
+  bclstack_put(&s, 5, 2, 0);
+  bclstack_put(&s, 7, 3, 1);
 
-  cl = bclstack_get(s); EXPECT_TRUE(cl->from == 7); EXPECT_TRUE(cl->length == 3); EXPECT_TRUE(cl->bit_pos == 1);
-  cl = bclstack_get(s); EXPECT_TRUE(cl->from == 5); EXPECT_TRUE(cl->length == 2); EXPECT_TRUE(cl->bit_pos == 0);
+  EXPECT_TRUE(bclstack_length(&s) == 3);
 
-  EXPECT_TRUE(bclstack_length(s) == 1);
+  cl = bclstack_get(&s); EXPECT_TRUE(cl->from == 7); EXPECT_TRUE(cl->length == 3); EXPECT_TRUE(cl->bit_pos == 1);
+  cl = bclstack_get(&s); EXPECT_TRUE(cl->from == 5); EXPECT_TRUE(cl->length == 2); EXPECT_TRUE(cl->bit_pos == 0);
 
-  bclstack_put(s, 999, 888, 777);
-  bclstack_put(s, 12, 34, 56);
+  EXPECT_TRUE(bclstack_length(&s) == 1);
 
-  EXPECT_TRUE(bclstack_length(s) == 3);
+  bclstack_put(&s, 999, 888, 777);
+  bclstack_put(&s, 12, 34, 56);
 
-  cl = bclstack_get(s); EXPECT_TRUE(cl->from == 12); EXPECT_TRUE(cl->length == 34); EXPECT_TRUE(cl->bit_pos == 56);
-  cl = bclstack_get(s); EXPECT_TRUE(cl->from == 999); EXPECT_TRUE(cl->length == 888); EXPECT_TRUE(cl->bit_pos == 777);
-  cl = bclstack_get(s); EXPECT_TRUE(cl->from == 0); EXPECT_TRUE(cl->length == 5); EXPECT_TRUE(cl->bit_pos == 0);
-  EXPECT_TRUE(bclstack_get(s) == NULL);
+  EXPECT_TRUE(bclstack_length(&s) == 3);
 
-  EXPECT_TRUE(bclstack_length(s) == 0);
-  EXPECT_TRUE(bclstack_empty(s));
+  cl = bclstack_get(&s); EXPECT_TRUE(cl->from == 12); EXPECT_TRUE(cl->length == 34); EXPECT_TRUE(cl->bit_pos == 56);
+  cl = bclstack_get(&s); EXPECT_TRUE(cl->from == 999); EXPECT_TRUE(cl->length == 888); EXPECT_TRUE(cl->bit_pos == 777);
+  cl = bclstack_get(&s); EXPECT_TRUE(cl->from == 0); EXPECT_TRUE(cl->length == 5); EXPECT_TRUE(cl->bit_pos == 0);
+  EXPECT_TRUE(bclstack_get(&s) == NULL);
 
-  bclstack_free(&s);
+  EXPECT_TRUE(bclstack_length(&s) == 0);
+  EXPECT_TRUE(bclstack_empty(&s));
 
   return 1;
 }

--- a/tests/unit/unit_tests.c
+++ b/tests/unit/unit_tests.c
@@ -50,7 +50,7 @@ int main()
   RUN_TEST(test_bsreader_read_7);
   RUN_TEST(test_bsreader_size);
 
-  RUN_TEST(test_bclstack_new);
+  RUN_TEST(test_bclstack_init);
   RUN_TEST(test_bclstack_put_and_get);
 
   RUN_TEST(test_count_zeros_at_bit_pos8);

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -55,7 +55,7 @@ int test_bsreader_read_6(void);
 int test_bsreader_read_7(void);
 int test_bsreader_size(void);
 
-int test_bclstack_new(void);
+int test_bclstack_init(void);
 int test_bclstack_put_and_get(void);
 
 int test_count_zeros_at_bit_pos8(void);


### PR DESCRIPTION
It also removes this annoying warning when compiling:
```
bitstream.h:84:6: warning: ‘*((void *)&ctx+40).end_ptr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```