### PR TITLE
Do not use typedef for internal structs

### DIFF
--- a/bitstream.h
+++ b/bitstream.h
@@ -16,13 +16,13 @@
 #define BIT_STREAM_MAX_WRITE 57
 #define BIT_STREAM_MAX_READ BIT_STREAM_MAX_WRITE
 
-typedef struct {
-  uint64_t bit_container;
-  unsigned int bit_pos;
-  uint8_t *start_ptr;
-  uint8_t *ptr;
-  uint8_t *end_ptr;
-} BSWriter;
+struct BSWriter {
+  uint64_t      bit_container;
+  unsigned int  bit_pos;
+  uint8_t       *start_ptr;
+  uint8_t       *ptr;
+  uint8_t       *end_ptr;
+};
 
 static inline size_t bswriter_align_buffer_size(size_t orig_size)
 {
@@ -30,7 +30,8 @@ static inline size_t bswriter_align_buffer_size(size_t orig_size)
   return orig_size + 8 - (orig_size % 8);
 }
 
-static inline VtencErrorCode bswriter_init(BSWriter *writer, uint8_t *out_buf, size_t out_capacity)
+static inline VtencErrorCode bswriter_init(struct BSWriter *writer,
+  uint8_t *out_buf, size_t out_capacity)
 {
   writer->bit_container = 0;
   writer->bit_pos = 0;
@@ -42,7 +43,8 @@ static inline VtencErrorCode bswriter_init(BSWriter *writer, uint8_t *out_buf, s
   return VtencErrorNoError;
 }
 
-static inline void bswriter_append(BSWriter *writer, uint64_t value, unsigned int n_bits)
+static inline void bswriter_append(struct BSWriter *writer,
+  uint64_t value, unsigned int n_bits)
 {
   assert(n_bits <= BIT_STREAM_MAX_WRITE);
   assert(n_bits + writer->bit_pos < 64);
@@ -51,7 +53,7 @@ static inline void bswriter_append(BSWriter *writer, uint64_t value, unsigned in
   writer->bit_pos += n_bits;
 }
 
-static inline VtencErrorCode bswriter_flush(BSWriter *writer)
+static inline VtencErrorCode bswriter_flush(struct BSWriter *writer)
 {
   size_t const n_bytes = writer->bit_pos >> 3;
 
@@ -65,7 +67,8 @@ static inline VtencErrorCode bswriter_flush(BSWriter *writer)
   return VtencErrorNoError;
 }
 
-static inline VtencErrorCode bswriter_write(BSWriter *writer, uint64_t value, unsigned int n_bits)
+static inline VtencErrorCode bswriter_write(struct BSWriter *writer,
+  uint64_t value, unsigned int n_bits)
 {
   assert(n_bits <= BIT_STREAM_MAX_WRITE);
 
@@ -79,7 +82,7 @@ static inline VtencErrorCode bswriter_write(BSWriter *writer, uint64_t value, un
   return VtencErrorNoError;
 }
 
-static inline size_t bswriter_close(BSWriter *writer)
+static inline size_t bswriter_close(struct BSWriter *writer)
 {
   if (writer->ptr <= writer->end_ptr)
     bswriter_flush(writer);

--- a/bitstream.h
+++ b/bitstream.h
@@ -90,16 +90,17 @@ static inline size_t bswriter_close(struct BSWriter *writer)
   return (writer->ptr - writer->start_ptr) + (writer->bit_pos > 0);
 }
 
-typedef struct {
-  uint64_t bit_container;
-  unsigned int bits_loaded;
-  unsigned int bits_consumed;
+struct BSReader {
+  uint64_t      bit_container;
+  unsigned int  bits_loaded;
+  unsigned int  bits_consumed;
   const uint8_t *start_ptr;
   const uint8_t *ptr;
   const uint8_t *end_ptr;
-} BSReader;
+};
 
-static inline void bsreader_init(BSReader *reader, const uint8_t *buf, size_t buf_len)
+static inline void bsreader_init(struct BSReader *reader,
+  const uint8_t *buf, size_t buf_len)
 {
   reader->bit_container = 0;
   reader->bits_loaded = 0;
@@ -109,7 +110,7 @@ static inline void bsreader_init(BSReader *reader, const uint8_t *buf, size_t bu
   reader->end_ptr = reader->start_ptr + buf_len;
 }
 
-static inline VtencErrorCode bsreader_load(BSReader *reader)
+static inline VtencErrorCode bsreader_load(struct BSReader *reader)
 {
   size_t n_bytes;
 
@@ -144,7 +145,8 @@ static inline VtencErrorCode bsreader_load(BSReader *reader)
   return VtencErrorNoError;
 }
 
-static inline VtencErrorCode bsreader_read(BSReader *reader, unsigned int n_bits, uint64_t *read_value)
+static inline VtencErrorCode bsreader_read(struct BSReader *reader,
+  unsigned int n_bits, uint64_t *read_value)
 {
   assert(n_bits <= BIT_STREAM_MAX_READ);
 
@@ -161,7 +163,7 @@ static inline VtencErrorCode bsreader_read(BSReader *reader, unsigned int n_bits
   return VtencErrorNoError;
 }
 
-static inline size_t bsreader_size(BSReader *reader)
+static inline size_t bsreader_size(struct BSReader *reader)
 {
   return (reader->ptr - reader->start_ptr) + (reader->bits_consumed >> 3) + ((reader->bits_consumed & 7) > 0);
 }

--- a/decode_generic.h
+++ b/decode_generic.h
@@ -46,7 +46,7 @@ struct DecodeCtx(WIDTH) {
   int                     reconstruct_full_subtrees;
   size_t                  min_cluster_length;
   struct BitClusterStack  cl_stack;
-  BSReader                bits_reader;
+  struct BSReader         bits_reader;
 };
 
 static VtencErrorCode decctx_init(WIDTH)(struct DecodeCtx(WIDTH) *ctx,

--- a/encode_generic.h
+++ b/encode_generic.h
@@ -49,7 +49,7 @@ struct EncodeCtx(WIDTH) {
   int                     skip_full_subtrees;
   size_t                  min_cluster_length;
   struct BitClusterStack  cl_stack;
-  BSWriter                bits_writer;
+  struct BSWriter         bits_writer;
 };
 
 static VtencErrorCode encctx_init(WIDTH)(struct EncodeCtx(WIDTH) *ctx,

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -26,7 +26,7 @@ int test_bswriter_align_buffer_size(void)
 
 int test_bswriter_init_1(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 4;
   uint8_t buf[buf_cap];
 
@@ -37,7 +37,7 @@ int test_bswriter_init_1(void)
 
 int test_bswriter_init_2(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 8;
   uint8_t buf[buf_cap];
 
@@ -48,7 +48,7 @@ int test_bswriter_init_2(void)
 
 int test_bswriter_write_1(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 16;
   uint8_t buf[buf_cap];
 
@@ -73,7 +73,7 @@ int test_bswriter_write_1(void)
 
 int test_bswriter_write_2(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 8;
   uint8_t buf[buf_cap];
 
@@ -99,7 +99,7 @@ int test_bswriter_write_2(void)
 
 int test_bswriter_write_3(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 24;
   uint8_t buf[buf_cap];
 
@@ -123,7 +123,7 @@ int test_bswriter_write_3(void)
 
 int test_bswriter_close_1(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 8;
   uint8_t buf[buf_cap];
 
@@ -135,7 +135,7 @@ int test_bswriter_close_1(void)
 
 int test_bswriter_close_2(void)
 {
-  BSWriter writer;
+  struct BSWriter writer;
   const size_t buf_cap = 8;
   uint8_t buf[buf_cap];
 

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -153,7 +153,7 @@ int test_bswriter_close_2(void)
 
 int test_bsreader_read_1(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {};
   const size_t buf_len = sizeof(buf);
   uint64_t val=0;
@@ -167,7 +167,7 @@ int test_bsreader_read_1(void)
 
 int test_bsreader_read_2(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {0xff};
   const size_t buf_len = sizeof(buf);
   uint64_t val=0;
@@ -182,7 +182,7 @@ int test_bsreader_read_2(void)
 
 int test_bsreader_read_3(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {0xff, 0x66};
   const size_t buf_len = sizeof(buf);
   uint64_t val=0;
@@ -198,7 +198,7 @@ int test_bsreader_read_3(void)
 
 int test_bsreader_read_4(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {0xba};
   const size_t buf_len = sizeof(buf);
   uint64_t val=0;
@@ -217,7 +217,7 @@ int test_bsreader_read_4(void)
 
 int test_bsreader_read_5(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {
     0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
     0x33, 0x33, 0x33, 0x33, 0x33, 0x33
@@ -237,7 +237,7 @@ int test_bsreader_read_5(void)
 
 int test_bsreader_read_6(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {
     0xff, 0xab, 0x11, 0xcd, 0x55, 0x55, 0x55, 0x55, 0x66, 0x66, 0x66, 0x66
   };
@@ -264,7 +264,7 @@ int test_bsreader_read_6(void)
 
 int test_bsreader_read_7(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {
     0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
     0x55, 0x55, 0x55
@@ -283,7 +283,7 @@ int test_bsreader_read_7(void)
 
 int test_bsreader_size(void)
 {
-  BSReader reader;
+  struct BSReader reader;
   const uint8_t buf[] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
   };


### PR DESCRIPTION
Minor change to keep consistency on not to use `typedef` for internal structures. Removes `typedef` in `BSWriter` and `BSReader` struct declarations.