### PR TITLE
Removes -g3 gcc flag for all targets, except debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TESTSDIR = tests
 UNITTESTSDIR = tests/unit
 
 CC = gcc
-CFLAGS = -std=c99 -Wall -O3 -g3 -march=native -mtune=native
+CFLAGS = -std=c99 -Wall -O3 -march=native -mtune=native
 DEBUGFLAGS = -std=c99 -Wall -O0 -g3
 LDFLAGS = -shared
 AR = ar


### PR DESCRIPTION
The `-g3` flag was generating bloated `.a` and `.so` files.

**BEFORE:**

![Screenshot from 2022-02-25 17-14-50](https://user-images.githubusercontent.com/4749171/155758313-11b073e9-b8f7-4463-ac2c-b1d506c661db.png)

**AFTER:**

![Screenshot from 2022-02-25 17-15-29](https://user-images.githubusercontent.com/4749171/155758398-57a0d936-3bf0-4d56-8d33-4556b4658cf3.png)
