### PR TITLE
Add branch for when input value is 0 on `bits_len_u64` & `bits_len_u32`

### DIFF
--- a/bits.h
+++ b/bits.h
@@ -149,7 +149,11 @@ static inline unsigned int bits_len_u16(uint16_t value)
 static inline unsigned int bits_len_u32(uint32_t value)
 {
 #ifdef __HAVE_BUILTIN_CLZ__
-  return 32 - __builtin_clz(value | 1);
+  if (value == 0) {
+    return 1;
+  } else {
+    return 32 - __builtin_clz(value);
+  }
 #else
   unsigned int n = 0;
 
@@ -169,7 +173,11 @@ static inline unsigned int bits_len_u32(uint32_t value)
 static inline unsigned int bits_len_u64(uint64_t value)
 {
 #ifdef __HAVE_BUILTIN_CLZLL__
-  return 64 - __builtin_clzll(value | 1ULL);
+  if (value == 0) {
+    return 1;
+  } else {
+    return 64 - __builtin_clzll(value);
+  }
 #else
   unsigned int n = 0;
 


### PR DESCRIPTION
Before, we were passing in `value | 1` to `__builtin_clz` function to make sure that the input is at least 1 and prevent an undefined result (https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html). That was a way to avoid adding a branch to treat the special case of the input value being 0. However, by avoiding a branch we were adding 1 instruction (OR) to be executed every time, which had an impact in a function that's called so frequently.

It turns out that adding the branch for the rare case of value=0 is a good idea as the processor will probably predict it correctly.