### PR TITLE
Branchless bitstream writer

### DIFF
--- a/bitstream.h
+++ b/bitstream.h
@@ -23,8 +23,7 @@ struct bswriter {
 
 static inline size_t bswriter_align_buffer_size(size_t orig_size)
 {
-  if ((orig_size > 0) && (orig_size%8 == 0)) return orig_size;
-  return orig_size + 8 - (orig_size % 8);
+  return orig_size + 8;
 }
 
 static inline int bswriter_init(struct bswriter *writer,

--- a/bitstream.h
+++ b/bitstream.h
@@ -72,6 +72,8 @@ static inline int bswriter_write(struct bswriter *writer,
   const unsigned int total_bits = writer->bit_pos + n_bits;
   const unsigned int n_bytes = total_bits >> 3;
 
+  if (writer->ptr >= writer->end_ptr) return VTENC_ERR_END_OF_STREAM;
+
   writer->bit_container |= value << writer->bit_pos;
 
   mem_write_le_u64(writer->ptr, writer->bit_container);

--- a/bitstream.h
+++ b/bitstream.h
@@ -56,13 +56,14 @@ static inline int bswriter_flush(struct bswriter *writer)
 {
   size_t const n_bytes = writer->bit_pos >> 3;
 
+  if (writer->ptr >= writer->end_ptr) return VTENC_ERR_END_OF_STREAM;
+
   mem_write_le_u64(writer->ptr, writer->bit_container);
 
   writer->ptr += n_bytes;
   writer->bit_pos &= 7;
   writer->bit_container >>= (n_bytes << 3);
 
-  if (writer->ptr > writer->end_ptr) return VTENC_ERR_END_OF_STREAM;
   return VTENC_OK;
 }
 

--- a/bitstream.h
+++ b/bitstream.h
@@ -85,9 +85,6 @@ static inline int bswriter_write(struct bswriter *writer,
 
 static inline size_t bswriter_close(struct bswriter *writer)
 {
-  if (writer->ptr <= writer->end_ptr)
-    bswriter_flush(writer);
-
   return (writer->ptr - writer->start_ptr) + (writer->bit_pos > 0);
 }
 

--- a/bitstream.h
+++ b/bitstream.h
@@ -85,7 +85,7 @@ static inline int bswriter_write(struct bswriter *writer,
   return VTENC_OK;
 }
 
-static inline size_t bswriter_close(struct bswriter *writer)
+static inline size_t bswriter_size(struct bswriter *writer)
 {
   return (writer->ptr - writer->start_ptr) + (writer->bit_pos > 0);
 }

--- a/bitstream.h
+++ b/bitstream.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "compiler.h"
 #include "internals.h"
 #include "mem.h"
 
@@ -54,9 +55,11 @@ static inline void bswriter_append(struct bswriter *writer,
 
 static inline int bswriter_flush(struct bswriter *writer)
 {
-  size_t const n_bytes = writer->bit_pos >> 3;
+  const unsigned int n_bytes = writer->bit_pos >> 3;
 
-  if (writer->ptr >= writer->end_ptr) return VTENC_ERR_END_OF_STREAM;
+  if (unlikely(writer->ptr >= writer->end_ptr)) {
+    return VTENC_ERR_END_OF_STREAM;
+  }
 
   mem_write_le_u64(writer->ptr, writer->bit_container);
 
@@ -73,7 +76,9 @@ static inline int bswriter_write(struct bswriter *writer,
   const unsigned int total_bits = writer->bit_pos + n_bits;
   const unsigned int n_bytes = total_bits >> 3;
 
-  if (writer->ptr >= writer->end_ptr) return VTENC_ERR_END_OF_STREAM;
+  if (unlikely(writer->ptr >= writer->end_ptr)) {
+    return VTENC_ERR_END_OF_STREAM;
+  }
 
   writer->bit_container |= value << writer->bit_pos;
 

--- a/bitstream.h
+++ b/bitstream.h
@@ -29,15 +29,15 @@ static inline size_t bswriter_align_buffer_size(size_t orig_size)
 static inline int bswriter_init(struct bswriter *writer,
   uint8_t *out_buf, size_t out_capacity)
 {
+  if (out_capacity < sizeof(writer->bit_container)) {
+    return VTENC_ERR_BUFFER_TOO_SMALL;
+  }
+
   writer->bit_container = 0;
   writer->bit_pos = 0;
   writer->start_ptr = out_buf;
   writer->ptr = writer->start_ptr;
   writer->end_ptr = writer->start_ptr + out_capacity - sizeof(writer->bit_container);
-
-  if (out_capacity < sizeof(writer->bit_container)) {
-    return VTENC_ERR_BUFFER_TOO_SMALL;
-  }
 
   return VTENC_OK;
 }

--- a/compiler.h
+++ b/compiler.h
@@ -24,4 +24,7 @@
 #define __HAVE_BUILTIN_CLZLL__
 #endif
 
+#define likely(x)  __builtin_expect(!!(x), 1)
+#define unlikely(x)  __builtin_expect(!!(x), 0)
+
 #endif /* VTENC_COMPILER_H_ */

--- a/encode_generic.h
+++ b/encode_generic.h
@@ -67,7 +67,7 @@ static int encctx_init(struct encctx *ctx, const vtenc *enc,
 
 static inline size_t encctx_close(struct encctx *ctx)
 {
-  return bswriter_close(&(ctx->bits_writer));
+  return bswriter_size(&(ctx->bits_writer));
 }
 
 static inline int encode_lower_bits_step(struct encctx *ctx,

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -49,10 +49,9 @@ int test_bswriter_init_2(void)
 int test_bswriter_write_1(void)
 {
   struct bswriter writer;
-  const size_t buf_cap = 16;
+  const size_t buf_sz = 10;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
   uint8_t buf[buf_cap];
-
-  memset(buf, 0, buf_cap);
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
@@ -66,7 +65,7 @@ int test_bswriter_write_1(void)
 
   bswriter_close(&writer);
 
-  EXPECT_TRUE(memcmp(buf, "\xff\xff\x22\x00\x99\x99\x99\x99\x44\xaa\x00\x00\x00\x00\x00\x00", buf_cap) == 0);
+  EXPECT_TRUE(memcmp(buf, "\xff\xff\x22\x00\x99\x99\x99\x99\x44\xaa", buf_sz) == 0);
 
   return 1;
 }
@@ -74,10 +73,9 @@ int test_bswriter_write_1(void)
 int test_bswriter_write_2(void)
 {
   struct bswriter writer;
-  const size_t buf_cap = 8;
+  const size_t buf_sz = 8;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
   uint8_t buf[buf_cap];
-
-  memset(buf, 0, buf_cap);
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
@@ -87,12 +85,12 @@ int test_bswriter_write_2(void)
   EXPECT_TRUE(bswriter_write(&writer, 0x7fffffff, 31) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_ERR_END_OF_STREAM);
+  EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_ERR_END_OF_STREAM);
 
   bswriter_close(&writer);
 
-  EXPECT_TRUE(memcmp(buf, "\xff\xff\xff\xff\xff\xff\xff\x7f", buf_cap) == 0);
+  EXPECT_TRUE(memcmp(buf, "\xff\xff\xff\xff\xff\xff\xff\xff", buf_sz) == 0);
 
   return 1;
 }
@@ -100,7 +98,8 @@ int test_bswriter_write_2(void)
 int test_bswriter_write_3(void)
 {
   struct bswriter writer;
-  const size_t buf_cap = 24;
+  const size_t buf_sz = 24;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
   uint8_t buf[buf_cap];
 
   memset(buf, 0, buf_cap);
@@ -116,7 +115,7 @@ int test_bswriter_write_3(void)
   EXPECT_TRUE(memcmp(buf,
     "\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff"
-    "\xff\xff\xff\xff\xff\x07\x00\x00", buf_cap) == 0);
+    "\xff\xff\xff\xff\xff\x07\x00\x00", buf_sz) == 0);
 
   return 1;
 }
@@ -124,7 +123,8 @@ int test_bswriter_write_3(void)
 int test_bswriter_close_1(void)
 {
   struct bswriter writer;
-  const size_t buf_cap = 8;
+  const size_t buf_sz = 8;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
   uint8_t buf[buf_cap];
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
@@ -136,7 +136,8 @@ int test_bswriter_close_1(void)
 int test_bswriter_close_2(void)
 {
   struct bswriter writer;
-  const size_t buf_cap = 8;
+  const size_t buf_sz = 8;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
   uint8_t buf[buf_cap];
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -12,14 +12,14 @@
 int test_bswriter_align_buffer_size(void)
 {
   EXPECT_TRUE(bswriter_align_buffer_size(0) == 8);
-  EXPECT_TRUE(bswriter_align_buffer_size(1) == 8);
-  EXPECT_TRUE(bswriter_align_buffer_size(7) == 8);
-  EXPECT_TRUE(bswriter_align_buffer_size(8) == 8);
-  EXPECT_TRUE(bswriter_align_buffer_size(9) == 16);
-  EXPECT_TRUE(bswriter_align_buffer_size(13) == 16);
-  EXPECT_TRUE(bswriter_align_buffer_size(16) == 16);
-  EXPECT_TRUE(bswriter_align_buffer_size(33) == 40);
-  EXPECT_TRUE(bswriter_align_buffer_size(48) == 48);
+  EXPECT_TRUE(bswriter_align_buffer_size(1) == 9);
+  EXPECT_TRUE(bswriter_align_buffer_size(7) == 15);
+  EXPECT_TRUE(bswriter_align_buffer_size(8) == 16);
+  EXPECT_TRUE(bswriter_align_buffer_size(9) == 17);
+  EXPECT_TRUE(bswriter_align_buffer_size(13) == 21);
+  EXPECT_TRUE(bswriter_align_buffer_size(16) == 24);
+  EXPECT_TRUE(bswriter_align_buffer_size(33) == 41);
+  EXPECT_TRUE(bswriter_align_buffer_size(48) == 56);
 
   return 1;
 }

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -114,6 +114,27 @@ int test_bswriter_write_3(void)
   return 1;
 }
 
+int test_bswriter_append_and_flush(void)
+{
+  struct bswriter writer;
+  const size_t buf_sz = 5;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
+  uint8_t buf[buf_cap];
+
+  EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
+
+  bswriter_append(&writer, 0xffff, 16);
+  bswriter_append(&writer, 0x55, 8);
+  bswriter_append(&writer, 0xabab, 16);
+
+  EXPECT_TRUE(bswriter_flush(&writer) == VTENC_OK);
+  EXPECT_TRUE(bswriter_flush(&writer) == VTENC_ERR_END_OF_STREAM);
+
+  EXPECT_TRUE(memcmp(buf, "\xff\xff\x55\xab\xab", buf_sz) == 0);
+
+  return 1;
+}
+
 int test_bswriter_size_1(void)
 {
   struct bswriter writer;

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -63,8 +63,6 @@ int test_bswriter_write_1(void)
   EXPECT_TRUE(bswriter_write(&writer, 0x44, 8) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0xaa, 8) == VTENC_OK);
 
-  bswriter_close(&writer);
-
   EXPECT_TRUE(memcmp(buf, "\xff\xff\x22\x00\x99\x99\x99\x99\x44\xaa", buf_sz) == 0);
 
   return 1;
@@ -88,8 +86,6 @@ int test_bswriter_write_2(void)
   EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_ERR_END_OF_STREAM);
 
-  bswriter_close(&writer);
-
   EXPECT_TRUE(memcmp(buf, "\xff\xff\xff\xff\xff\xff\xff\xff", buf_sz) == 0);
 
   return 1;
@@ -110,8 +106,6 @@ int test_bswriter_write_3(void)
   EXPECT_TRUE(bswriter_write(&writer, 0x1ffffffffffffff, 57) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0x1ffffffffffffff, 57) == VTENC_OK);
 
-  bswriter_close(&writer);
-
   EXPECT_TRUE(memcmp(buf,
     "\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff"
@@ -120,7 +114,7 @@ int test_bswriter_write_3(void)
   return 1;
 }
 
-int test_bswriter_close_1(void)
+int test_bswriter_size_1(void)
 {
   struct bswriter writer;
   const size_t buf_sz = 8;
@@ -128,12 +122,12 @@ int test_bswriter_close_1(void)
   uint8_t buf[buf_cap];
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
-  EXPECT_TRUE(bswriter_close(&writer) == 0);
+  EXPECT_TRUE(bswriter_size(&writer) == 0);
 
   return 1;
 }
 
-int test_bswriter_close_2(void)
+int test_bswriter_size_2(void)
 {
   struct bswriter writer;
   const size_t buf_sz = 8;
@@ -147,7 +141,7 @@ int test_bswriter_close_2(void)
   EXPECT_TRUE(bswriter_write(&writer, 0x7, 3) == VTENC_OK);
   EXPECT_TRUE(bswriter_write(&writer, 0xe, 4) == VTENC_OK);
 
-  EXPECT_TRUE(bswriter_close(&writer) == 3);
+  EXPECT_TRUE(bswriter_size(&writer) == 3);
 
   return 1;
 }

--- a/tests/unit/encode_test.c
+++ b/tests/unit/encode_test.c
@@ -1298,56 +1298,56 @@ int test_vtenc_encode64(void)
 
 int test_vtenc_max_encoded_size8(void)
 {
-  EXPECT_TRUE(vtenc_max_encoded_size8(0) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size8(1) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size8(7) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size8(8) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size8(15) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size8(16) == 24);
-  EXPECT_TRUE(vtenc_max_encoded_size8(100) == 104);
-  EXPECT_TRUE(vtenc_max_encoded_size8(1000) == 1008);
+  EXPECT_TRUE(vtenc_max_encoded_size8(0) == 9);
+  EXPECT_TRUE(vtenc_max_encoded_size8(1) == 10);
+  EXPECT_TRUE(vtenc_max_encoded_size8(7) == 16);
+  EXPECT_TRUE(vtenc_max_encoded_size8(8) == 17);
+  EXPECT_TRUE(vtenc_max_encoded_size8(15) == 24);
+  EXPECT_TRUE(vtenc_max_encoded_size8(16) == 25);
+  EXPECT_TRUE(vtenc_max_encoded_size8(100) == 109);
+  EXPECT_TRUE(vtenc_max_encoded_size8(1000) == 1009);
 
   return 1;
 }
 
 int test_vtenc_max_encoded_size16(void)
 {
-  EXPECT_TRUE(vtenc_max_encoded_size16(0) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size16(1) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size16(3) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size16(4) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size16(7) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size16(8) == 24);
-  EXPECT_TRUE(vtenc_max_encoded_size16(10) == 24);
-  EXPECT_TRUE(vtenc_max_encoded_size16(100) == 208);
-  EXPECT_TRUE(vtenc_max_encoded_size16(1000) == 2008);
+  EXPECT_TRUE(vtenc_max_encoded_size16(0) == 10);
+  EXPECT_TRUE(vtenc_max_encoded_size16(1) == 12);
+  EXPECT_TRUE(vtenc_max_encoded_size16(3) == 16);
+  EXPECT_TRUE(vtenc_max_encoded_size16(4) == 18);
+  EXPECT_TRUE(vtenc_max_encoded_size16(7) == 24);
+  EXPECT_TRUE(vtenc_max_encoded_size16(8) == 26);
+  EXPECT_TRUE(vtenc_max_encoded_size16(10) == 30);
+  EXPECT_TRUE(vtenc_max_encoded_size16(100) == 210);
+  EXPECT_TRUE(vtenc_max_encoded_size16(1000) == 2010);
 
   return 1;
 }
 
 int test_vtenc_max_encoded_size32(void)
 {
-  EXPECT_TRUE(vtenc_max_encoded_size32(0) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size32(1) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size32(2) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size32(3) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size32(4) == 24);
-  EXPECT_TRUE(vtenc_max_encoded_size32(10) == 48);
-  EXPECT_TRUE(vtenc_max_encoded_size32(100) == 408);
-  EXPECT_TRUE(vtenc_max_encoded_size32(1000) == 4008);
+  EXPECT_TRUE(vtenc_max_encoded_size32(0) == 12);
+  EXPECT_TRUE(vtenc_max_encoded_size32(1) == 16);
+  EXPECT_TRUE(vtenc_max_encoded_size32(2) == 20);
+  EXPECT_TRUE(vtenc_max_encoded_size32(3) == 24);
+  EXPECT_TRUE(vtenc_max_encoded_size32(4) == 28);
+  EXPECT_TRUE(vtenc_max_encoded_size32(10) == 52);
+  EXPECT_TRUE(vtenc_max_encoded_size32(100) == 412);
+  EXPECT_TRUE(vtenc_max_encoded_size32(1000) == 4012);
 
   return 1;
 }
 
 int test_vtenc_max_encoded_size64(void)
 {
-  EXPECT_TRUE(vtenc_max_encoded_size64(0) == 8);
-  EXPECT_TRUE(vtenc_max_encoded_size64(1) == 16);
-  EXPECT_TRUE(vtenc_max_encoded_size64(2) == 24);
-  EXPECT_TRUE(vtenc_max_encoded_size64(3) == 32);
-  EXPECT_TRUE(vtenc_max_encoded_size64(10) == 88);
-  EXPECT_TRUE(vtenc_max_encoded_size64(100) == 808);
-  EXPECT_TRUE(vtenc_max_encoded_size64(1000) == 8008);
+  EXPECT_TRUE(vtenc_max_encoded_size64(0) == 16);
+  EXPECT_TRUE(vtenc_max_encoded_size64(1) == 24);
+  EXPECT_TRUE(vtenc_max_encoded_size64(2) == 32);
+  EXPECT_TRUE(vtenc_max_encoded_size64(3) == 40);
+  EXPECT_TRUE(vtenc_max_encoded_size64(10) == 96);
+  EXPECT_TRUE(vtenc_max_encoded_size64(100) == 816);
+  EXPECT_TRUE(vtenc_max_encoded_size64(1000) == 8016);
 
   return 1;
 }

--- a/tests/unit/unit_tests.c
+++ b/tests/unit/unit_tests.c
@@ -38,8 +38,8 @@ int main()
   RUN_TEST(test_bswriter_write_1);
   RUN_TEST(test_bswriter_write_2);
   RUN_TEST(test_bswriter_write_3);
-  RUN_TEST(test_bswriter_close_1);
-  RUN_TEST(test_bswriter_close_2);
+  RUN_TEST(test_bswriter_size_1);
+  RUN_TEST(test_bswriter_size_2);
 
   RUN_TEST(test_bsreader_read_1);
   RUN_TEST(test_bsreader_read_2);

--- a/tests/unit/unit_tests.c
+++ b/tests/unit/unit_tests.c
@@ -38,6 +38,7 @@ int main()
   RUN_TEST(test_bswriter_write_1);
   RUN_TEST(test_bswriter_write_2);
   RUN_TEST(test_bswriter_write_3);
+  RUN_TEST(test_bswriter_append_and_flush);
   RUN_TEST(test_bswriter_size_1);
   RUN_TEST(test_bswriter_size_2);
 

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -43,6 +43,7 @@ int test_bswriter_init_2(void);
 int test_bswriter_write_1(void);
 int test_bswriter_write_2(void);
 int test_bswriter_write_3(void);
+int test_bswriter_append_and_flush(void);
 int test_bswriter_size_1(void);
 int test_bswriter_size_2(void);
 

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -43,8 +43,8 @@ int test_bswriter_init_2(void);
 int test_bswriter_write_1(void);
 int test_bswriter_write_2(void);
 int test_bswriter_write_3(void);
-int test_bswriter_close_1(void);
-int test_bswriter_close_2(void);
+int test_bswriter_size_1(void);
+int test_bswriter_size_2(void);
 
 int test_bsreader_read_1(void);
 int test_bsreader_read_2(void);


### PR DESCRIPTION
Re-writes `bswriter_write` function to remove unnecessary branches which have an impact on the performance.

Before, `bswriter_write` was using the `bswriter_append` and `bswriter_flush` functions to write bits to the buffer. The function had to check if the temporal bit container had capacity to append the provided number of bits before doing it. If its capacity had reached its limit, the function would flush the container into the buffer and then append the bits. This is an inefficient process.

The use case for using `bswriter_append` & `bswriter_flush` functions is when you know how many times you need to call append before having to call flush. In this scenario, the combination of the 2 functions yield a better performance than calling `bswriter_write` alone. Unfortunately, at the moment the number of bits to be written is calculated and it varies on each step in the VTEnc algorithm.