### PR TITLE
Branchless bitstream reader

### DIFF
--- a/bitstream.h
+++ b/bitstream.h
@@ -98,7 +98,6 @@ static inline size_t bswriter_size(struct bswriter *writer)
 
 struct bsreader {
   uint64_t      bit_container;
-  unsigned int  bits_loaded;
   unsigned int  bits_consumed;
   const uint8_t *start_ptr;
   const uint8_t *ptr;
@@ -109,7 +108,6 @@ static inline void bsreader_init(struct bsreader *reader,
   const uint8_t *buf, size_t buf_len)
 {
   reader->bit_container = 0;
-  reader->bits_loaded = 0;
   reader->bits_consumed = 0;
   reader->start_ptr = buf;
   reader->ptr = reader->start_ptr;

--- a/bitstream.h
+++ b/bitstream.h
@@ -98,7 +98,7 @@ static inline size_t bswriter_size(struct bswriter *writer)
 
 struct bsreader {
   uint64_t      bit_container;
-  unsigned int  bits_consumed;
+  unsigned int  bit_pos;
   const uint8_t *start_ptr;
   const uint8_t *ptr;
   const uint8_t *end_ptr;
@@ -108,7 +108,7 @@ static inline void bsreader_init(struct bsreader *reader,
   const uint8_t *buf, size_t buf_len)
 {
   reader->bit_container = 0;
-  reader->bits_consumed = 0;
+  reader->bit_pos = 0;
   reader->start_ptr = buf;
   reader->ptr = reader->start_ptr;
   reader->end_ptr = reader->start_ptr + buf_len;
@@ -138,16 +138,16 @@ static inline int bsreader_read(struct bsreader *reader,
     }
   }
 
-  *read_value = (reader->bit_container >> reader->bits_consumed) & ((1ULL << n_bits) - 1ULL);
-  reader->ptr += (reader->bits_consumed + n_bits) >> 3;
-  reader->bits_consumed = (reader->bits_consumed + n_bits) & 7;
+  *read_value = (reader->bit_container >> reader->bit_pos) & ((1ULL << n_bits) - 1ULL);
+  reader->ptr += (reader->bit_pos + n_bits) >> 3;
+  reader->bit_pos = (reader->bit_pos + n_bits) & 7;
 
   return VTENC_OK;
 }
 
 static inline size_t bsreader_size(struct bsreader *reader)
 {
-  return (reader->ptr - reader->start_ptr) + (reader->bits_consumed >> 3) + ((reader->bits_consumed & 7) > 0);
+  return (reader->ptr - reader->start_ptr) + (reader->bit_pos >> 3) + ((reader->bit_pos & 7) > 0);
 }
 
 #endif /* VTENC_BITSTREAM_H_ */

--- a/bitstream.h
+++ b/bitstream.h
@@ -140,10 +140,6 @@ static inline int bsreader_read(struct bsreader *reader,
     }
   }
 
-  if ((reader->bits_consumed + n_bits) > ((reader->end_ptr - reader->ptr) << 3)) {
-    return VTENC_ERR_NOT_ENOUGH_BITS;
-  }
-
   *read_value = (reader->bit_container >> reader->bits_consumed) & ((1ULL << n_bits) - 1ULL);
   reader->ptr += (reader->bits_consumed + n_bits) >> 3;
   reader->bits_consumed = (reader->bits_consumed + n_bits) & 7;

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -206,8 +206,8 @@ int test_bsreader_read_3(void)
   bsreader_init(&reader, buf, buf_len);
 
   EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0xff);
-  EXPECT_TRUE(bsreader_read(&reader, 16, &val) == VTENC_ERR_NOT_ENOUGH_BITS);
   EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0x66);
+  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
 
   return 1;
 }

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -225,7 +225,6 @@ int test_bsreader_read_4(void)
   EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xa);
   EXPECT_TRUE(bsreader_read(&reader, 0, &val) == VTENC_OK);
   EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xb);
-  EXPECT_TRUE(bsreader_read(&reader, 0, &val) == VTENC_OK);
   EXPECT_TRUE(bsreader_read(&reader, 1, &val) == VTENC_ERR_END_OF_STREAM);
 
   return 1;

--- a/vtenc.h
+++ b/vtenc.h
@@ -30,11 +30,10 @@ extern "C" {
 #define VTENC_OK                    0     /* Successful code */
 #define VTENC_ERR_BUFFER_TOO_SMALL  (-1)  /* Buffer too small */
 #define VTENC_ERR_END_OF_STREAM     (-2)  /* Write or Read reaches end of the stream */
-#define VTENC_ERR_NOT_ENOUGH_BITS   (-3)  /* Not enough bits to read */
-#define VTENC_ERR_INPUT_TOO_BIG     (-4)  /* Input size too big */
-#define VTENC_ERR_OUTPUT_TOO_BIG    (-5)  /* Output size too big */
-#define VTENC_ERR_WRONG_FORMAT      (-6)  /* Wrong encoded format */
-#define VTENC_ERR_CONFIG            (-7)  /* Unrecognised config option */
+#define VTENC_ERR_INPUT_TOO_BIG     (-3)  /* Input size too big */
+#define VTENC_ERR_OUTPUT_TOO_BIG    (-4)  /* Output size too big */
+#define VTENC_ERR_WRONG_FORMAT      (-5)  /* Wrong encoded format */
+#define VTENC_ERR_CONFIG            (-6)  /* Unrecognised config option */
 
 /* Encoding/decoding handler */
 typedef struct vtenc vtenc;


### PR DESCRIPTION
Simplifies bit stream readers by merging the logic of `bsreader_load` and `bsreader_read` into the latter function. It also removes unnecessary branches, which has a positive impact on the decoding speed. The gain is around 10%-15% when decoding random sets and up to 20% for the `gov2` data set.