### PR TITLE
Do not return result code from bitstream functions

### DIFF
--- a/bitstream.h
+++ b/bitstream.h
@@ -53,42 +53,32 @@ static inline void bswriter_append(struct bswriter *writer,
   writer->bit_pos += n_bits;
 }
 
-static inline int bswriter_flush(struct bswriter *writer)
+static inline void bswriter_flush(struct bswriter *writer)
 {
   const unsigned int n_bytes = writer->bit_pos >> 3;
 
-  if (unlikely(writer->ptr >= writer->end_ptr)) {
-    return VTENC_ERR_END_OF_STREAM;
-  }
-
+  assert(writer->ptr < writer->end_ptr);
   mem_write_le_u64(writer->ptr, writer->bit_container);
 
   writer->ptr += n_bytes;
   writer->bit_pos &= 7;
   writer->bit_container >>= (n_bytes << 3);
-
-  return VTENC_OK;
 }
 
-static inline int bswriter_write(struct bswriter *writer,
+static inline void bswriter_write(struct bswriter *writer,
   uint64_t value, unsigned int n_bits)
 {
   const unsigned int total_bits = writer->bit_pos + n_bits;
   const unsigned int n_bytes = total_bits >> 3;
 
-  if (unlikely(writer->ptr >= writer->end_ptr)) {
-    return VTENC_ERR_END_OF_STREAM;
-  }
-
   writer->bit_container |= value << writer->bit_pos;
 
+  assert(writer->ptr < writer->end_ptr);
   mem_write_le_u64(writer->ptr, writer->bit_container);
 
   writer->ptr += n_bytes;
   writer->bit_pos = total_bits & 7;
   writer->bit_container >>= (n_bytes << 3);
-
-  return VTENC_OK;
 }
 
 static inline size_t bswriter_size(struct bswriter *writer)

--- a/bitstream.h
+++ b/bitstream.h
@@ -104,14 +104,12 @@ static inline void bsreader_init(struct bsreader *reader,
   reader->end_ptr = reader->start_ptr + buf_len;
 }
 
-static inline int bsreader_read(struct bsreader *reader,
+static inline void bsreader_read(struct bsreader *reader,
   unsigned int n_bits, uint64_t *read_value)
 {
   const unsigned int n_bytes = reader->end_ptr - reader->ptr;
 
-  if (reader->ptr >= reader->end_ptr) {
-    return VTENC_ERR_END_OF_STREAM;
-  }
+  assert(reader->ptr < reader->end_ptr);
 
   if (n_bytes >= 8) {
     reader->bit_container = mem_read_le_u64(reader->ptr);
@@ -131,8 +129,6 @@ static inline int bsreader_read(struct bsreader *reader,
   *read_value = (reader->bit_container >> reader->bit_pos) & ((1ULL << n_bits) - 1ULL);
   reader->ptr += (reader->bit_pos + n_bits) >> 3;
   reader->bit_pos = (reader->bit_pos + n_bits) & 7;
-
-  return VTENC_OK;
 }
 
 static inline size_t bsreader_size(struct bsreader *reader)

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -55,13 +55,13 @@ int test_bswriter_write_1(void)
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
-  EXPECT_TRUE(bswriter_write(&writer, 0xffff, 16) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x2, 4) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x2, 4) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x00, 8) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x99999999, 32) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x44, 8) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0xaa, 8) == VTENC_OK);
+  bswriter_write(&writer, 0xffff, 16);
+  bswriter_write(&writer, 0x2, 4);
+  bswriter_write(&writer, 0x2, 4);
+  bswriter_write(&writer, 0x00, 8);
+  bswriter_write(&writer, 0x99999999, 32);
+  bswriter_write(&writer, 0x44, 8);
+  bswriter_write(&writer, 0xaa, 8);
 
   EXPECT_TRUE(memcmp(buf, "\xff\xff\x22\x00\x99\x99\x99\x99\x44\xaa", buf_sz) == 0);
 
@@ -77,14 +77,13 @@ int test_bswriter_write_2(void)
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
-  EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0xffffffff, 32) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x7fffffff, 31) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x0, 0) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x1, 1) == VTENC_ERR_END_OF_STREAM);
+  bswriter_write(&writer, 0x0, 0);
+  bswriter_write(&writer, 0x0, 0);
+  bswriter_write(&writer, 0xffffffff, 32);
+  bswriter_write(&writer, 0x7fffffff, 31);
+  bswriter_write(&writer, 0x0, 0);
+  bswriter_write(&writer, 0x0, 0);
+  bswriter_write(&writer, 0x1, 1);
 
   EXPECT_TRUE(memcmp(buf, "\xff\xff\xff\xff\xff\xff\xff\xff", buf_sz) == 0);
 
@@ -102,9 +101,9 @@ int test_bswriter_write_3(void)
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
-  EXPECT_TRUE(bswriter_write(&writer, 0x1ffffffffffffff, 57) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x1ffffffffffffff, 57) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x1ffffffffffffff, 57) == VTENC_OK);
+  bswriter_write(&writer, 0x1ffffffffffffff, 57);
+  bswriter_write(&writer, 0x1ffffffffffffff, 57);
+  bswriter_write(&writer, 0x1ffffffffffffff, 57);
 
   EXPECT_TRUE(memcmp(buf,
     "\xff\xff\xff\xff\xff\xff\xff\xff"
@@ -127,8 +126,7 @@ int test_bswriter_append_and_flush(void)
   bswriter_append(&writer, 0x55, 8);
   bswriter_append(&writer, 0xabab, 16);
 
-  EXPECT_TRUE(bswriter_flush(&writer) == VTENC_OK);
-  EXPECT_TRUE(bswriter_flush(&writer) == VTENC_ERR_END_OF_STREAM);
+  bswriter_flush(&writer);
 
   EXPECT_TRUE(memcmp(buf, "\xff\xff\x55\xab\xab", buf_sz) == 0);
 
@@ -157,10 +155,10 @@ int test_bswriter_size_2(void)
 
   EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
 
-  EXPECT_TRUE(bswriter_write(&writer, 0x12, 8) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x3, 2) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0x7, 3) == VTENC_OK);
-  EXPECT_TRUE(bswriter_write(&writer, 0xe, 4) == VTENC_OK);
+  bswriter_write(&writer, 0x12, 8);
+  bswriter_write(&writer, 0x3, 2);
+  bswriter_write(&writer, 0x7, 3);
+  bswriter_write(&writer, 0xe, 4);
 
   EXPECT_TRUE(bswriter_size(&writer) == 3);
 
@@ -170,49 +168,22 @@ int test_bswriter_size_2(void)
 int test_bsreader_read_1(void)
 {
   struct bsreader reader;
-  const uint8_t buf[] = {};
-  const size_t buf_len = sizeof(buf);
-  uint64_t val=0;
-
-  bsreader_init(&reader, buf, buf_len);
-
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
-
-  return 1;
-}
-
-int test_bsreader_read_2(void)
-{
-  struct bsreader reader;
-  const uint8_t buf[] = {0xff};
-  const size_t buf_len = sizeof(buf);
-  uint64_t val=0;
-
-  bsreader_init(&reader, buf, buf_len);
-
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0xff);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
-
-  return 1;
-}
-
-int test_bsreader_read_3(void)
-{
-  struct bsreader reader;
   const uint8_t buf[] = {0xff, 0x66};
   const size_t buf_len = sizeof(buf);
   uint64_t val=0;
 
   bsreader_init(&reader, buf, buf_len);
 
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0xff);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0x66);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
+  bsreader_read(&reader, 8, &val);
+  EXPECT_TRUE(val == 0xff);
+
+  bsreader_read(&reader, 8, &val);
+  EXPECT_TRUE(val == 0x66);
 
   return 1;
 }
 
-int test_bsreader_read_4(void)
+int test_bsreader_read_2(void)
 {
   struct bsreader reader;
   const uint8_t buf[] = {0xba};
@@ -221,16 +192,18 @@ int test_bsreader_read_4(void)
 
   bsreader_init(&reader, buf, buf_len);
 
-  EXPECT_TRUE(bsreader_read(&reader, 0, &val) == VTENC_OK);
-  EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xa);
-  EXPECT_TRUE(bsreader_read(&reader, 0, &val) == VTENC_OK);
-  EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xb);
-  EXPECT_TRUE(bsreader_read(&reader, 1, &val) == VTENC_ERR_END_OF_STREAM);
+  bsreader_read(&reader, 0, &val);
+  bsreader_read(&reader, 4, &val);
+  EXPECT_TRUE(val == 0xa);
+
+  bsreader_read(&reader, 0, &val);
+  bsreader_read(&reader, 4, &val);
+  EXPECT_TRUE(val == 0xb);
 
   return 1;
 }
 
-int test_bsreader_read_5(void)
+int test_bsreader_read_3(void)
 {
   struct bsreader reader;
   const uint8_t buf[] = {
@@ -242,15 +215,19 @@ int test_bsreader_read_5(void)
 
   bsreader_init(&reader, buf, buf_len);
 
-  EXPECT_TRUE(bsreader_read(&reader, 48, &val) == VTENC_OK && val == 0x111111111111);
-  EXPECT_TRUE(bsreader_read(&reader, 48, &val) == VTENC_OK && val == 0x222222222222);
-  EXPECT_TRUE(bsreader_read(&reader, 48, &val) == VTENC_OK && val == 0x333333333333);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
+  bsreader_read(&reader, 48, &val);
+  EXPECT_TRUE(val == 0x111111111111);
+
+  bsreader_read(&reader, 48, &val);
+  EXPECT_TRUE(val == 0x222222222222);
+
+  bsreader_read(&reader, 48, &val);
+  EXPECT_TRUE(val == 0x333333333333);
 
   return 1;
 }
 
-int test_bsreader_read_6(void)
+int test_bsreader_read_4(void)
 {
   struct bsreader reader;
   const uint8_t buf[] = {
@@ -261,23 +238,43 @@ int test_bsreader_read_6(void)
 
   bsreader_init(&reader, buf, buf_len);
 
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0xff);
-  EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xb);
-  EXPECT_TRUE(bsreader_read(&reader, 4, &val) == VTENC_OK && val == 0xa);
-  EXPECT_TRUE(bsreader_read(&reader, 1, &val) == VTENC_OK && val == 0x1);
-  EXPECT_TRUE(bsreader_read(&reader, 2, &val) == VTENC_OK && val == 0x0);
-  EXPECT_TRUE(bsreader_read(&reader, 2, &val) == VTENC_OK && val == 0x2);
-  EXPECT_TRUE(bsreader_read(&reader, 3, &val) == VTENC_OK && val == 0x0);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_OK && val == 0xcd);
-  EXPECT_TRUE(bsreader_read(&reader, 16, &val) == VTENC_OK && val == 0x5555);
-  EXPECT_TRUE(bsreader_read(&reader, 16, &val) == VTENC_OK && val == 0x5555);
-  EXPECT_TRUE(bsreader_read(&reader, 32, &val) == VTENC_OK && val == 0x66666666);
-  EXPECT_TRUE(bsreader_read(&reader, 8, &val) == VTENC_ERR_END_OF_STREAM);
+  bsreader_read(&reader, 8, &val);
+  EXPECT_TRUE(val == 0xff);
+
+  bsreader_read(&reader, 4, &val);
+  EXPECT_TRUE(val == 0xb);
+
+  bsreader_read(&reader, 4, &val);
+  EXPECT_TRUE(val == 0xa);
+
+  bsreader_read(&reader, 1, &val);
+  EXPECT_TRUE(val == 0x1);
+
+  bsreader_read(&reader, 2, &val);
+  EXPECT_TRUE(val == 0x0);
+
+  bsreader_read(&reader, 2, &val);
+  EXPECT_TRUE(val == 0x2);
+
+  bsreader_read(&reader, 3, &val);
+  EXPECT_TRUE(val == 0x0);
+
+  bsreader_read(&reader, 8, &val);
+  EXPECT_TRUE(val == 0xcd);
+
+  bsreader_read(&reader, 16, &val);
+  EXPECT_TRUE(val == 0x5555);
+
+  bsreader_read(&reader, 16, &val);
+  EXPECT_TRUE(val == 0x5555);
+
+  bsreader_read(&reader, 32, &val);
+  EXPECT_TRUE(val == 0x66666666);
 
   return 1;
 }
 
-int test_bsreader_read_7(void)
+int test_bsreader_read_5(void)
 {
   struct bsreader reader;
   const uint8_t buf[] = {
@@ -289,9 +286,14 @@ int test_bsreader_read_7(void)
 
   bsreader_init(&reader, buf, buf_len);
 
-  EXPECT_TRUE(bsreader_read(&reader, 57, &val) == VTENC_OK && val == 0x155555555555555);
-  EXPECT_TRUE(bsreader_read(&reader, 57, &val) == VTENC_OK && val == 0x0aaaaaaaaaaaaaa);
-  EXPECT_TRUE(bsreader_read(&reader, 6, &val) == VTENC_OK && val == 0x15);
+  bsreader_read(&reader, 57, &val);
+  EXPECT_TRUE(val == 0x155555555555555);
+
+  bsreader_read(&reader, 57, &val);
+  EXPECT_TRUE(val == 0x0aaaaaaaaaaaaaa);
+
+  bsreader_read(&reader, 6, &val);
+  EXPECT_TRUE(val == 0x15);
 
   return 1;
 }

--- a/tests/unit/unit_tests.c
+++ b/tests/unit/unit_tests.c
@@ -47,8 +47,6 @@ int main()
   RUN_TEST(test_bsreader_read_3);
   RUN_TEST(test_bsreader_read_4);
   RUN_TEST(test_bsreader_read_5);
-  RUN_TEST(test_bsreader_read_6);
-  RUN_TEST(test_bsreader_read_7);
   RUN_TEST(test_bsreader_size);
 
   RUN_TEST(test_stack_init);

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -52,8 +52,6 @@ int test_bsreader_read_2(void);
 int test_bsreader_read_3(void);
 int test_bsreader_read_4(void);
 int test_bsreader_read_5(void);
-int test_bsreader_read_6(void);
-int test_bsreader_read_7(void);
 int test_bsreader_size(void);
 
 int test_stack_init(void);

--- a/vtenc.h
+++ b/vtenc.h
@@ -29,11 +29,10 @@ extern "C" {
  */
 #define VTENC_OK                    0     /* Successful code */
 #define VTENC_ERR_BUFFER_TOO_SMALL  (-1)  /* Buffer too small */
-#define VTENC_ERR_END_OF_STREAM     (-2)  /* Write or Read reaches end of the stream */
-#define VTENC_ERR_INPUT_TOO_BIG     (-3)  /* Input size too big */
-#define VTENC_ERR_OUTPUT_TOO_BIG    (-4)  /* Output size too big */
-#define VTENC_ERR_WRONG_FORMAT      (-5)  /* Wrong encoded format */
-#define VTENC_ERR_CONFIG            (-6)  /* Unrecognised config option */
+#define VTENC_ERR_INPUT_TOO_BIG     (-2)  /* Input size too big */
+#define VTENC_ERR_OUTPUT_TOO_BIG    (-3)  /* Output size too big */
+#define VTENC_ERR_WRONG_FORMAT      (-4)  /* Wrong encoded format */
+#define VTENC_ERR_CONFIG            (-5)  /* Unrecognised config option */
 
 /* Encoding/decoding handler */
 typedef struct vtenc vtenc;


### PR DESCRIPTION
Changes return value of `bswriter_append`, `bswriter_write` and `bsreader_read` functions from `int` to `void`.

The current return value for these functions is a result code that indicates success or failure. The only controlled error that was being handled was `VTENC_ERR_END_OF_STREAM` which happens when the end of the stream is reached by trying to write or read bits.

This PR changes the mentioned functions by removing the current end-of-stream check so the user must create a bit stream big enough to avoid that specific error. An assertion has been added to make sure that no write or read occur outside of the boundaries of the stream.

The main benefit of this change is that code using these bitstream functions doesn't need to check if something went wrong every time that they're called. That means that code is simpler and potentially more efficient as some branches have been removed.