### PR TITLE
Add -DNDEBUG to compiling flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TESTSDIR = tests
 UNITTESTSDIR = tests/unit
 
 CC = gcc
-CFLAGS = -std=c99 -Wall -O3 -march=native -mtune=native
+CFLAGS = -std=c99 -Wall -DNDEBUG -O3 -march=native -mtune=native
 DEBUGFLAGS = -std=c99 -Wall -O0 -g3
 LDFLAGS = -shared
 AR = ar


### PR DESCRIPTION
The `NDEBUG` macro is used to enable or disable assertions using `assert`. Defining the macro through compile flags will make `assert` functions do nothing, so they won't affect performance.

The `assert` function is intended to be used as a debugging tool. With this new setup, it's safe (and encouraged) to add assertions to check "unexpected" errors.

To enable assertions, compile with `make debug`.