### PR TITLE
Add `bswriter_append_fast`

### DIFF
--- a/bitstream.h
+++ b/bitstream.h
@@ -49,6 +49,20 @@ static inline void bswriter_append(struct bswriter *writer,
   assert(n_bits <= BIT_STREAM_MAX_WRITE);
   assert(n_bits + writer->bit_pos < 64);
 
+  writer->bit_container |= (value & BITS_SIZE_MASK[n_bits]) << writer->bit_pos;
+  writer->bit_pos += n_bits;
+}
+
+/*
+ * It only works if `value` is clean, meaning that all
+ * high bits above `n_bits` are 0.
+ */
+static inline void bswriter_append_fast(struct bswriter *writer,
+  uint64_t value, unsigned int n_bits)
+{
+  assert(n_bits <= BIT_STREAM_MAX_WRITE);
+  assert(n_bits + writer->bit_pos < 64);
+
   writer->bit_container |= value << writer->bit_pos;
   writer->bit_pos += n_bits;
 }
@@ -62,7 +76,7 @@ static inline void bswriter_flush(struct bswriter *writer)
 
   writer->ptr += n_bytes;
   writer->bit_pos &= 7;
-  writer->bit_container >>= (n_bytes << 3);
+  writer->bit_container >>= n_bytes << 3;
 }
 
 static inline void bswriter_write(struct bswriter *writer,

--- a/encodebits.inc.h
+++ b/encodebits.inc.h
@@ -20,16 +20,17 @@ static inline void batch1(
 {
 #if BITWIDTH == 64
   uint64_t value = values[0];
-
   if (n_bits > BIT_STREAM_MAX_WRITE) {
-    bswriter_write(writer, value & BITS_SIZE_MASK[BIT_STREAM_MAX_WRITE], BIT_STREAM_MAX_WRITE);
+    bswriter_append(writer, value, BIT_STREAM_MAX_WRITE);
+    bswriter_flush(writer);
     value >>= BIT_STREAM_MAX_WRITE;
     n_bits -= BIT_STREAM_MAX_WRITE;
   }
-
-  bswriter_write(writer, value & BITS_SIZE_MASK[n_bits], n_bits);
+  bswriter_append(writer, value, n_bits);
+  bswriter_flush(writer);
 #else
-  bswriter_write(writer, values[0] & BITS_SIZE_MASK[n_bits], n_bits);
+  bswriter_append(writer, values[0], n_bits);
+  bswriter_flush(writer);
 #endif
 }
 
@@ -38,8 +39,8 @@ static inline void batch2(
   const TYPE *values,
   unsigned int n_bits)
 {
-  bswriter_append(writer, values[0] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[1] & BITS_SIZE_MASK[n_bits], n_bits);
+  bswriter_append(writer, values[0], n_bits);
+  bswriter_append(writer, values[1], n_bits);
   bswriter_flush(writer);
 }
 
@@ -48,9 +49,9 @@ static inline void batch3(
   const TYPE *values,
   unsigned int n_bits)
 {
-  bswriter_append(writer, values[0] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[1] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[2] & BITS_SIZE_MASK[n_bits], n_bits);
+  bswriter_append(writer, values[0], n_bits);
+  bswriter_append(writer, values[1], n_bits);
+  bswriter_append(writer, values[2], n_bits);
   bswriter_flush(writer);
 }
 
@@ -59,10 +60,10 @@ static inline void batch4(
   const TYPE *values,
   unsigned int n_bits)
 {
-  bswriter_append(writer, values[0] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[1] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[2] & BITS_SIZE_MASK[n_bits], n_bits);
-  bswriter_append(writer, values[3] & BITS_SIZE_MASK[n_bits], n_bits);
+  bswriter_append(writer, values[0], n_bits);
+  bswriter_append(writer, values[1], n_bits);
+  bswriter_append(writer, values[2], n_bits);
+  bswriter_append(writer, values[3], n_bits);
   bswriter_flush(writer);
 }
 

--- a/encodebits.inc.h
+++ b/encodebits.inc.h
@@ -3,7 +3,6 @@
   Licensed under the MIT License.
   See LICENSE file in the project root for full license information.
  */
-#include "bits.h"
 #include "bitstream.h"
 #include "internals.h"
 

--- a/tests/unit/bitstream_test.c
+++ b/tests/unit/bitstream_test.c
@@ -138,6 +138,26 @@ int test_bswriter_append_and_flush(void)
   return 1;
 }
 
+int test_bswriter_append_fast_and_flush(void)
+{
+  struct bswriter writer;
+  const size_t buf_sz = 5;
+  const size_t buf_cap = bswriter_align_buffer_size(buf_sz);
+  uint8_t buf[buf_cap];
+
+  EXPECT_TRUE(bswriter_init(&writer, buf, buf_cap) == VTENC_OK);
+
+  bswriter_append_fast(&writer, 0xffff, 16);
+  bswriter_append_fast(&writer, 0x55, 8);
+  bswriter_append_fast(&writer, 0xabab, 16);
+
+  bswriter_flush(&writer);
+
+  EXPECT_TRUE(memcmp(buf, "\xff\xff\x55\xab\xab", buf_sz) == 0);
+
+  return 1;
+}
+
 int test_bswriter_size_1(void)
 {
   struct bswriter writer;

--- a/tests/unit/unit_tests.c
+++ b/tests/unit/unit_tests.c
@@ -39,6 +39,7 @@ int main()
   RUN_TEST(test_bswriter_write_2);
   RUN_TEST(test_bswriter_write_3);
   RUN_TEST(test_bswriter_append_and_flush);
+  RUN_TEST(test_bswriter_append_fast_and_flush);
   RUN_TEST(test_bswriter_size_1);
   RUN_TEST(test_bswriter_size_2);
 

--- a/tests/unit/unit_tests.h
+++ b/tests/unit/unit_tests.h
@@ -44,6 +44,7 @@ int test_bswriter_write_1(void);
 int test_bswriter_write_2(void);
 int test_bswriter_write_3(void);
 int test_bswriter_append_and_flush(void);
+int test_bswriter_append_fast_and_flush(void);
 int test_bswriter_size_1(void);
 int test_bswriter_size_2(void);
 


### PR DESCRIPTION
Adds `bswriter_append_fast` function that can be used when the provided value is "clean", meaning its higher bits are 0. As its name indicates, this function is faster than `bswriter_append`, although it can't always be used.

`bswriter_append` function has been updated to "mask" lower bits internally so there's no need to do it outside the function.